### PR TITLE
support GCP as auth provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1193,6 +1193,7 @@
     "pkg/apis/clientauthentication/v1beta1",
     "pkg/version",
     "plugin/pkg/client/auth/exec",
+    "plugin/pkg/client/auth/gcp",
     "rest",
     "rest/watch",
     "restmapper",

--- a/cmd/kubectl-flyte/cmd/root.go
+++ b/cmd/kubectl-flyte/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lyft/flytestdlib/version"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 


### PR DESCRIPTION
It is already possible to use `kubectl flyte --kubeconfig ~/.kube/config get ...` connecting to a GKE cluster. This PR makes GCP auth supported natively so GKE users will not need to point to kube config manually.