### PR TITLE
Advanced options to configure kube client for large scale deployments

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -6,8 +6,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/lyft/flytepropeller/pkg/controller/executors"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/lyft/flytepropeller/pkg/controller/executors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -36,11 +37,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	restclient "k8s.io/client-go/rest"
+
 	clientset "github.com/lyft/flytepropeller/pkg/client/clientset/versioned"
 	informers "github.com/lyft/flytepropeller/pkg/client/informers/externalversions"
 	"github.com/lyft/flytepropeller/pkg/controller"
 	"github.com/lyft/flytepropeller/pkg/signals"
-	restclient "k8s.io/client-go/rest"
 )
 
 const (
@@ -133,6 +135,10 @@ func getKubeConfig(_ context.Context, cfg *config2.Config) (*kubernetes.Clientse
 			return nil, nil, errors.Wrapf(err, "Cannot get InCluster kubeconfig")
 		}
 	}
+
+	kubecfg.QPS = cfg.KubeConfig.QPS
+	kubecfg.Burst = cfg.KubeConfig.Burst
+	kubecfg.Timeout = cfg.KubeConfig.Timeout.Duration
 
 	kubeClient, err := kubernetes.NewForConfig(kubecfg)
 	if err != nil {

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -31,6 +31,18 @@ type Config struct {
 	GCInterval          config.Duration      `json:"gc-interval" pflag:"\"30m\",Run periodic GC every 30 minutes"`
 	LeaderElection      LeaderElectionConfig `json:"leader-election,omitempty" pflag:",Config for leader election."`
 	PublishK8sEvents    bool                 `json:"publish-k8s-events" pflag:",Enable events publishing to K8s events API."`
+	KubeConfig          KubeClientConfig     `json:"kube-client-config" pflag:",Configuration to control the Kubernetes client"`
+}
+
+type KubeClientConfig struct {
+	// QPS indicates the maximum QPS to the master from this client.
+	// If it's zero, the created RESTClient will use DefaultQPS: 5
+	QPS float32 `json:"qps" pflag:",Max QPS to the master for requests to KubeAPI. 0 defaults to 5."`
+	// Maximum burst for throttle.
+	// If it's zero, the created RESTClient will use DefaultBurst: 10.
+	Burst int `json:"burst" pflag:",Max burst rate for throttle. 0 defaults to 10"`
+	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
+	Timeout config.Duration `json:"timeout" pflag:",Max duration allowed for every request to KubeAPI before giving up. 0 implies no timeout."`
 }
 
 type CompositeQueueType = string


### PR DESCRIPTION
Kubeclient has a built in rate limiter to prevent browning out the server. 
We have added special configuration that allows controlling the number of requests from each propeller. This directly affects the throughput of Flyte (in terms of number of workflows) that can be executed. 

Caution: this is an advanced configuration and should be tuned carefully, to maintain stability of the API servers.
