### PR TITLE
Generic type support in Workflow compiler

### DIFF
--- a/pkg/compiler/validators/typing_test.go
+++ b/pkg/compiler/validators/typing_test.go
@@ -221,6 +221,22 @@ func TestMapCasting(t *testing.T) {
 		assert.False(t, castable, "{k: Integer} should not be castable to {k: Float}")
 	})
 
+	t.Run("ScalarStructToStruct", func(t *testing.T) {
+		castable := AreTypesCastable(
+			&core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_STRUCT,
+				},
+			},
+			&core.LiteralType{
+				Type: &core.LiteralType_Simple{
+					Simple: core.SimpleType_STRUCT,
+				},
+			},
+		)
+		assert.True(t, castable, "castable from Struct to struct")
+	})
+
 	t.Run("MismatchedMapNestLevels_Scalar", func(t *testing.T) {
 		castable := AreTypesCastable(
 			&core.LiteralType{

--- a/pkg/compiler/validators/utils.go
+++ b/pkg/compiler/validators/utils.go
@@ -50,6 +50,8 @@ func literalTypeForScalar(scalar *core.Scalar) *core.LiteralType {
 		literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_NONE}}
 	case *core.Scalar_Error:
 		literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_ERROR}}
+	case *core.Scalar_Generic:
+		literalType = &core.LiteralType{Type: &core.LiteralType_Simple{Simple: core.SimpleType_STRUCT}}
 	default:
 		return nil
 	}


### PR DESCRIPTION
- For Scalar type Generic, the compiler was missing support. Added this support.