### PR TITLE
Bump IDL to 0.16.3

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,14 +53,6 @@
   version = "v0.1.3"
 
 [[projects]]
-  digest = "1:bc87d464fa4b9a3164657bfc05c9e48379456ae5771bba7d9d19ed9552135940"
-  name = "github.com/Masterminds/semver"
-  packages = ["."]
-  pruneopts = ""
-  revision = "25911d36c978be5eb3e81847734874fd4e1dc6c7"
-  version = "v3.0.2"
-
-[[projects]]
   digest = "1:ac3d2dc52be3b6976d3b7f9ac5089c794ca91e90d90d365851a0f944d5060e6c"
   name = "github.com/aws/aws-sdk-go"
   packages = [
@@ -1123,10 +1115,6 @@
     "discovery",
     "discovery/fake",
     "dynamic",
-    "informers/internalinterfaces",
-    "informers/node",
-    "informers/node/v1alpha1",
-    "informers/node/v1beta1",
     "kubernetes",
     "kubernetes/scheme",
     "kubernetes/typed/admissionregistration/v1",
@@ -1167,8 +1155,6 @@
     "kubernetes/typed/storage/v1",
     "kubernetes/typed/storage/v1alpha1",
     "kubernetes/typed/storage/v1beta1",
-    "listers/node/v1alpha1",
-    "listers/node/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -1332,7 +1318,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DiSiqueira/GoTree",
-    "github.com/Masterminds/semver",
     "github.com/dgrijalva/jwt-go",
     "github.com/fatih/color",
     "github.com/ghodss/yaml",
@@ -1416,11 +1401,11 @@
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/uuid",
+    "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",
-    "k8s.io/client-go/informers/node",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",
     "k8s.io/client-go/kubernetes/typed/coordination/v1",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -138,6 +138,14 @@
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:379d34d9efc755fab444199f007819fe99718640f9ccfbdd3f0430340bb02b07"
+  name = "github.com/coreos/go-oidc"
+  packages = ["."]
+  pruneopts = ""
+  revision = "2be1c5b8a260760503f66dc0996e102b683b3ac3"
+  version = "v2.1.0"
+
+[[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -432,7 +440,7 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:dec8d616f023c717c476cad2b30d5afebb4b6ed2f23d215bf309b9889c2a377b"
+  digest = "1:24508da9d4741637264e1f5deeceb58150415974ce08efe1f0764ffa881d833d"
   name = "github.com/lyft/flyteidl"
   packages = [
     "clients/go/admin",
@@ -448,11 +456,11 @@
     "gen/pb-go/flyteidl/service",
   ]
   pruneopts = ""
-  revision = "fac461ff1d6926e98b48e2f3374419afdb69de18"
-  version = "v0.14.1"
+  revision = "7f8cdc2cb0f613bb62b8b44167828326b733f8a5"
+  version = "v0.16.3"
 
 [[projects]]
-  digest = "1:0f2319c4da524090f6db2e99eaf2da31c907a81b39ff2c6b399c8288557f9648"
+  digest = "1:a91f67d1fe58f403725f532bb149f38bbfaeb7ad200ad84e862086c798d5cd4a"
   name = "github.com/lyft/flyteplugins"
   packages = [
     "go/tasks/aws",
@@ -490,8 +498,8 @@
     "tests",
   ]
   pruneopts = ""
-  revision = "3a30f6d7f5b17f788b2f28a6700ebf97b58dca0d"
-  version = "v0.2.2"
+  revision = "40c2addb5eebb6e5a1065b741cb8adcfcc32b818"
+  version = "v0.2.4"
 
 [[projects]]
   digest = "1:7fee6ae151d081a92d58a53099adcfccf89e424aef03eb20531ae0285da8613d"
@@ -610,6 +618,17 @@
   pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:de5481dda0c081b66450e391bbb1a5c4435b13e3c0bbf0133ba1a5baeda7b7af"
+  name = "github.com/pquerna/cachecontrol"
+  packages = [
+    ".",
+    "cacheobject",
+  ]
+  pruneopts = ""
+  revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
 
 [[projects]]
   digest = "1:c826496cad27bd9a7644a01230a79d472b4093dd33587236e8f8369bb1d8534e"
@@ -769,7 +788,12 @@
   branch = "master"
   digest = "1:af51232d5990d72e4be609640e2885c16db404ec419283caa6d97a311cb4e29d"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "pbkdf2",
+    "ssh/terminal",
+  ]
   pruneopts = ""
   revision = "e7c4368fe9ddd156b5f1463283cb51c5b400c373"
 
@@ -796,6 +820,7 @@
   name = "golang.org/x/oauth2"
   packages = [
     ".",
+    "clientcredentials",
     "google",
     "internal",
     "jws",
@@ -998,6 +1023,18 @@
   pruneopts = ""
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
+
+[[projects]]
+  digest = "1:edd75ef05376347c02f40c36f2896d4aee3b8cbfe8247299c71aefd7ca28f443"
+  name = "gopkg.in/square/go-jose.v2"
+  packages = [
+    ".",
+    "cipher",
+    "json",
+  ]
+  pruneopts = ""
+  revision = "4ef0f1b175ccd65472d154e1207c4d7b8102545f"
+  version = "v2.4.1"
 
 [[projects]]
   digest = "1:5a53f6ef09fb1ac261a97f8a72e8837ff53cbaa969022a6679da210e4cbe9b0f"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,7 +53,7 @@
   version = "v0.1.3"
 
 [[projects]]
-  digest = "1:ac3d2dc52be3b6976d3b7f9ac5089c794ca91e90d90d365851a0f944d5060e6c"
+  digest = "1:44f5b106511b7332c94ae0c5cb4d40302648bc082494bb3f59114219c3b9a117"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -102,8 +102,8 @@
     "service/sts/stsiface",
   ]
   pruneopts = ""
-  revision = "a25ea3950893fa501b1fc9619eb1b3546c7ad3a0"
-  version = "v1.26.5"
+  revision = "1f768889877d4ded796b018e2a711544728d867b"
+  version = "v1.26.6"
 
 [[projects]]
   branch = "master"
@@ -631,7 +631,7 @@
   revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
 
 [[projects]]
-  digest = "1:c826496cad27bd9a7644a01230a79d472b4093dd33587236e8f8369bb1d8534e"
+  digest = "1:6bea0cda3fc62855d5312163e7d259fb97e31692d93c08cfffbeb2d00df0f13c"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -795,7 +795,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0c8c3d0b028d56a91683bae1bd8a18cc672bb00eaf5797ee129916a61505128f"
+  digest = "1:51249205ab90861c8f2843e2ae875f92a7adc363efc8799c71c8ddbb4165ca00"
   name = "golang.org/x/crypto"
   packages = [
     "ed25519",
@@ -804,7 +804,7 @@
     "ssh/terminal",
   ]
   pruneopts = ""
-  revision = "e9b2fee46413994441b28dfca259d911d963dfed"
+  revision = "becbf705a91575484002d598f87d74f0002801e7"
 
 [[projects]]
   branch = "master"
@@ -840,14 +840,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:6e2cb00f85dc16f2f96b29fab5fb630ce884197003ba029c1c1769955f6ac339"
+  digest = "1:eeb3a40774a06a7fc3289fff7307d77397b0f16cb2b78a250df01b021ae287ae"
   name = "golang.org/x/sys"
   packages = [
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "4a24b406529242041050cb1dec3e0e4c46a5f1b6"
+  revision = "af0d71d358abe0ba3594483a5d519f429dbae3e9"
 
 [[projects]]
   digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
@@ -884,7 +884,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:384b352e7e1fe344c77506b70a19383fd588098819727f5a6de61fa99d48b4b8"
+  digest = "1:16feebd7ca91a6f155b5751ebdd7f3016ac4de992a42ee222c616840593b2a17"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -901,7 +901,7 @@
     "internal/semver",
   ]
   pruneopts = ""
-  revision = "61483d104abdaccec5e16baea23b99392ba3e779"
+  revision = "5e752206af050099b86f8738f3b6b5f69a08561b"
 
 [[projects]]
   branch = "master"
@@ -924,7 +924,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:da5cbe8386fbb57eb852ead8a40235ca4f71a54743d48de120d0de6a05b6c2ee"
+  digest = "1:75d7b3d422aa8b23e506f6f649a5b0ebf4bf703babd54e26230b6ec603067841"
   name = "google.golang.org/api"
   packages = [
     "googleapi",
@@ -938,7 +938,7 @@
     "transport/http/internal/propagation",
   ]
   pruneopts = ""
-  revision = "fe21b7c5cdfe2211cc8bb561b85502cda7e81685"
+  revision = "c28c262979b964300c57573a9dc590329c72f4de"
 
 [[projects]]
   digest = "1:c4404231035fad619a12f82ae3f0f8f9edc1cc7f34e7edad7a28ccac5336cc96"
@@ -1033,6 +1033,14 @@
   pruneopts = ""
   revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
   version = "v0.9.1"
+
+[[projects]]
+  digest = "1:b97a9fe409926ddb2f6a7a1f2b65476ba885e737a220a086554e00ecd7b530d8"
+  name = "gopkg.in/ini.v1"
+  packages = ["."]
+  pruneopts = ""
+  revision = "87e589f4917038ae250cff2446db7573f47e97ca"
+  version = "v1.51.0"
 
 [[projects]]
   digest = "1:edd75ef05376347c02f40c36f2896d4aee3b8cbfe8247299c71aefd7ca28f443"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,7 +49,7 @@ required = [
 
 [[constraint]]
   name = "github.com/lyft/flyteidl"
-  version = "^0.14.x"
+  version = "^0.16.x"
 
 [[constraint]]
   name = "github.com/lyft/datacatalog"


### PR DESCRIPTION
https://github.com/lyft/flyteidl/releases/tag/v0.16.3
which needs a bump to plugins to
https://github.com/lyft/flyteplugins/releases/tag/v0.2.4
