### PR TITLE
Fix invalid node lookup on abort/finalize

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -552,7 +552,7 @@ func (c *nodeExecutor) RecursiveNodeHandler(ctx context.Context, w v1alpha1.Exec
 }
 
 func (c *nodeExecutor) FinalizeHandler(ctx context.Context, w v1alpha1.ExecutableWorkflow, currentNode v1alpha1.ExecutableNode) error {
-	nodeStatus := w.GetExecutionStatus().GetNodeExecutionStatus(ctx, currentNode.GetID())
+	nodeStatus := w.GetNodeExecutionStatus(ctx, currentNode.GetID())
 
 	switch nodeStatus.GetPhase() {
 	case v1alpha1.NodePhaseFailing, v1alpha1.NodePhaseSucceeding, v1alpha1.NodePhaseRetryableFailure:
@@ -605,7 +605,7 @@ func (c *nodeExecutor) FinalizeHandler(ctx context.Context, w v1alpha1.Executabl
 }
 
 func (c *nodeExecutor) AbortHandler(ctx context.Context, w v1alpha1.ExecutableWorkflow, currentNode v1alpha1.ExecutableNode, reason string) error {
-	nodeStatus := w.GetExecutionStatus().GetNodeExecutionStatus(ctx, currentNode.GetID())
+	nodeStatus := w.GetNodeExecutionStatus(ctx, currentNode.GetID())
 
 	switch nodeStatus.GetPhase() {
 	case v1alpha1.NodePhaseRunning, v1alpha1.NodePhaseFailing, v1alpha1.NodePhaseSucceeding, v1alpha1.NodePhaseRetryableFailure, v1alpha1.NodePhaseQueued:

--- a/pkg/controller/nodes/task/k8s/plugin_manager.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager.go
@@ -152,7 +152,9 @@ func (e *PluginManager) getPodEffectiveResourceLimits(ctx context.Context, pod *
 			podRequestedResources[k] = qC
 		}
 	}
-	logger.Infof(ctx, "The resource requirement for creating Pod [%v] is [%v]\n", pod, podRequestedResources)
+
+	logger.Infof(ctx, "The resource requirement for creating Pod [%v/%v] is [%v]\n",
+		pod.Namespace, pod.Name, podRequestedResources)
 
 	return podRequestedResources
 }


### PR DESCRIPTION
Subworkflows used in Dynamic Node Handler override GetNodeExecutionStatus function from the parent workflow, however Abort and Finalize were not using that override and were instead using GetExecutionStatus().GetNodeExecutionStatus(). This would only successfully retrieve nodes that are directly in the workflow as opposed to ones that are present as subnodes of another node.