### PR TITLE
BugFix: Fix case in which Parent node in a Dynamic nodes finalize is not invoked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 bin
 .DS_Store
+_test

--- a/pkg/controller/nodes/task/handler.go
+++ b/pkg/controller/nodes/task/handler.go
@@ -573,7 +573,7 @@ func (t Handler) Finalize(ctx context.Context, nCtx handler.NodeExecutionContext
 			if r := recover(); r != nil {
 				t.metrics.pluginPanics.Inc(ctx)
 				stack := debug.Stack()
-				logger.Errorf(ctx, "Panic in plugin.Abort for TaskType [%s]", tCtx.tr.GetTaskType())
+				logger.Errorf(ctx, "Panic in plugin.Finalize for TaskType [%s]", tCtx.tr.GetTaskType())
 				err = fmt.Errorf("panic when executing a plugin for TaskType [%s]. Stack: [%s]", tCtx.tr.GetTaskType(), string(stack))
 			}
 		}()


### PR DESCRIPTION
Bug: In a Dynamic Node, Finalize for parent node is never invoked. This happens in all cases of a dynamic node. When finalizers are uses, the finalize method becomes extremely important.

Fix: Finalize for parent node is always invoked when dynamic node is finalized
Corollary: Parent node is finalized when dynamic node is finalized, i.e., after all child nodes have completed. Child nodes get finalized as they complete independently.