### PR TITLE
Add backslash to outputDir for outputwriter

### DIFF
--- a/pkg/controller/nodes/task/taskexec_context.go
+++ b/pkg/controller/nodes/task/taskexec_context.go
@@ -123,7 +123,8 @@ func (t *Handler) newTaskExecutionContext(ctx context.Context, nCtx handler.Node
 		return nil, err
 	}
 
-	ow := ioutils.NewBufferedOutputWriter(ctx, ioutils.NewRemoteFileOutputPaths(ctx, nCtx.DataStore(), nCtx.NodeStatus().GetOutputDir()))
+	// Append backslash to the outputDir
+	ow := ioutils.NewBufferedOutputWriter(ctx, ioutils.NewRemoteFileOutputPaths(ctx, nCtx.DataStore(), nCtx.NodeStatus().GetOutputDir() + "/"))
 	ts := nCtx.NodeStateReader().GetTaskNodeState()
 	var b *bytes.Buffer
 	if ts.PluginState != nil {

--- a/pkg/controller/nodes/task/taskexec_context_test.go
+++ b/pkg/controller/nodes/task/taskexec_context_test.go
@@ -50,7 +50,8 @@ func TestHandler_newTaskExecutionContext(t *testing.T) {
 
 	ns := &flyteMocks.ExecutableNodeStatus{}
 	ns.On("GetDataDir").Return(storage.DataReference("data-dir"))
-	ns.On("GetOutputDir").Return(storage.DataReference("output-dir"))
+	const outputDir = storage.DataReference("output-dir")
+	ns.On("GetOutputDir").Return(outputDir)
 
 	res := &v12.ResourceRequirements{}
 	n := &flyteMocks.ExecutableNode{}
@@ -116,6 +117,7 @@ func TestHandler_newTaskExecutionContext(t *testing.T) {
 	assert.NotNil(t, got.SecretManager())
 
 	assert.NotNil(t, got.OutputWriter())
+	assert.Equal(t, got.OutputWriter().GetOutputPrefixPath(), outputDir + "/")
 	assert.Equal(t, got.TaskExecutionMetadata().GetOverrides().GetResources(), res)
 
 	assert.Equal(t, got.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), "name-n1-1")


### PR DESCRIPTION
This is an alternative solution to: https://github.com/lyft/flytekit/pull/84. I don't know if this make sense for your guys but this allows us to not have to update all our existing workflows(update flytekit version if the other PR is merged and released).

Problem: When flyte propeller set the --output-prefix to {gcs_bucket}/propeller/{workflow_name}-development-{execution_id}/{task_name}/data/0, gsutil write the output.pb to /0 file instead of creating a new folder 0 and upload the file output.pb to the 0 folder. When flyte propeller trying to validate the '0' folder, it could not find output.pb file and fill the task.
Fix: Append / to the output dir fixes the issue