### PR TITLE
[wip] a regexp used to filter namespaces

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -59,7 +59,7 @@ type Config struct {
 	WorkflowReEval      config.Duration      `json:"workflow-reeval-duration" pflag:"\"30s\",Frequency of re-evaluating workflows"`
 	DownstreamEval      config.Duration      `json:"downstream-eval-duration" pflag:"\"60s\",Frequency of re-evaluating downstream tasks"`
 	LimitNamespace      string               `json:"limit-namespace" pflag:"\"all\",Namespaces to watch for this propeller"`
-	NamespaceFilter     string               `json:"namespace-filter" pflag:",Regular expression to apply fine grain filter when watching all namespaces"`
+	NamespaceFilter     config.Regexp        `json:"namespace-filter" pflag:",Regular expression to apply fine grain filter when watching all namespaces"`
 	ProfilerPort        config.Port          `json:"prof-port" pflag:"\"10254\",Profiler port"`
 	MetadataPrefix      string               `json:"metadata-prefix,omitempty" pflag:",MetadataPrefix should be used if all the metadata for Flyte executions should be stored under a specific prefix in CloudStorage. If not specified, the data will be stored in the base container directly."`
 	Queue               CompositeQueueConfig `json:"queue,omitempty" pflag:",Workflow workqueue configuration, affects the way the work is consumed from the queue."`

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	WorkflowReEval      config.Duration      `json:"workflow-reeval-duration" pflag:"\"30s\",Frequency of re-evaluating workflows"`
 	DownstreamEval      config.Duration      `json:"downstream-eval-duration" pflag:"\"60s\",Frequency of re-evaluating downstream tasks"`
 	LimitNamespace      string               `json:"limit-namespace" pflag:"\"all\",Namespaces to watch for this propeller"`
+	NamespaceFilter     string               `json:"namespace-filter" pflag:",Regular expression to apply fine grain filter when watching all namespaces"`
 	ProfilerPort        config.Port          `json:"prof-port" pflag:"\"10254\",Profiler port"`
 	MetadataPrefix      string               `json:"metadata-prefix,omitempty" pflag:",MetadataPrefix should be used if all the metadata for Flyte executions should be stored under a specific prefix in CloudStorage. If not specified, the data will be stored in the base container directly."`
 	Queue               CompositeQueueConfig `json:"queue,omitempty" pflag:",Workflow workqueue configuration, affects the way the work is consumed from the queue."`

--- a/pkg/controller/config/config_flags.go
+++ b/pkg/controller/config/config_flags.go
@@ -47,6 +47,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "workflow-reeval-duration"), defaultConfig.WorkflowReEval.String(), "Frequency of re-evaluating workflows")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "downstream-eval-duration"), defaultConfig.DownstreamEval.String(), "Frequency of re-evaluating downstream tasks")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "limit-namespace"), defaultConfig.LimitNamespace, "Namespaces to watch for this propeller")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "namespace-filter"), defaultConfig.NamespaceFilter, "Regular expression to apply fine grain filter when watching all namespaces")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "prof-port"), defaultConfig.ProfilerPort.String(), "Profiler port")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "metadata-prefix"), defaultConfig.MetadataPrefix, "MetadataPrefix should be used if all the metadata for Flyte executions should be stored under a specific prefix in CloudStorage. If not specified,  the data will be stored in the base container directly.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "queue.type"), defaultConfig.Queue.Type, "Type of composite queue to use for the WorkQueue")

--- a/pkg/controller/config/config_flags.go
+++ b/pkg/controller/config/config_flags.go
@@ -47,7 +47,7 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "workflow-reeval-duration"), defaultConfig.WorkflowReEval.String(), "Frequency of re-evaluating workflows")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "downstream-eval-duration"), defaultConfig.DownstreamEval.String(), "Frequency of re-evaluating downstream tasks")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "limit-namespace"), defaultConfig.LimitNamespace, "Namespaces to watch for this propeller")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "namespace-filter"), defaultConfig.NamespaceFilter, "Regular expression to apply fine grain filter when watching all namespaces")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "namespace-filter"), defaultConfig.NamespaceFilter.String(), "Regular expression to apply fine grain filter when watching all namespaces")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "prof-port"), defaultConfig.ProfilerPort.String(), "Profiler port")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "metadata-prefix"), defaultConfig.MetadataPrefix, "MetadataPrefix should be used if all the metadata for Flyte executions should be stored under a specific prefix in CloudStorage. If not specified,  the data will be stored in the base container directly.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "queue.type"), defaultConfig.Queue.Type, "Type of composite queue to use for the WorkQueue")

--- a/pkg/controller/config/config_flags_test.go
+++ b/pkg/controller/config/config_flags_test.go
@@ -231,6 +231,28 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_namespace-filter", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vString, err := cmdFlags.GetString("namespace-filter"); err == nil {
+				assert.Equal(t, string(defaultConfig.NamespaceFilter), vString)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("namespace-filter", testValue)
+			if vString, err := cmdFlags.GetString("namespace-filter"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vString), &actual.NamespaceFilter)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_prof-port", func(t *testing.T) {
 		t.Run("DefaultValue", func(t *testing.T) {
 			// Test that default value is set properly

--- a/pkg/controller/config/config_flags_test.go
+++ b/pkg/controller/config/config_flags_test.go
@@ -235,14 +235,14 @@ func TestConfig_SetFlags(t *testing.T) {
 		t.Run("DefaultValue", func(t *testing.T) {
 			// Test that default value is set properly
 			if vString, err := cmdFlags.GetString("namespace-filter"); err == nil {
-				assert.Equal(t, string(defaultConfig.NamespaceFilter), vString)
+				assert.Equal(t, string(defaultConfig.NamespaceFilter.String()), vString)
 			} else {
 				assert.FailNow(t, err.Error())
 			}
 		})
 
 		t.Run("Override", func(t *testing.T) {
-			testValue := "1"
+			testValue := defaultConfig.NamespaceFilter.String()
 
 			cmdFlags.Set("namespace-filter", testValue)
 			if vString, err := cmdFlags.GetString("namespace-filter"); err == nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -54,10 +54,10 @@ type Controller struct {
 	workflowStore       workflowstore.FlyteWorkflow
 	// recorder is an event recorder for recording Event resources to the
 	// Kubernetes API.
-	recorder         record.EventRecorder
-	metrics          *metrics
-	leaderElector    *leaderelection.LeaderElector
-	namespaceFilterR *regexp.Regexp
+	recorder              record.EventRecorder
+	metrics               *metrics
+	leaderElector         *leaderelection.LeaderElector
+	namespaceFilterRegexp *regexp.Regexp
 }
 
 // Runs either as a leader -if configured- or as a standalone process.
@@ -109,8 +109,8 @@ func (c *Controller) onStartedLeading(ctx context.Context) {
 
 // Skip the workflow if its namespace does not match namespace filter when defined
 func (c *Controller) skipWorkflow(ctx context.Context, namespace, name string) bool {
-	if c.namespaceFilterR != nil && !c.namespaceFilterR.MatchString(namespace) {
-		logger.Infof(ctx, "Skip workflow [%s] in namespace [%s], filtered out by namespace filter regexp [%s]", name, namespace, c.namespaceFilterR)
+	if c.namespaceFilterRegexp != nil && !c.namespaceFilterRegexp.MatchString(namespace) {
+		logger.Infof(ctx, "Skip workflow [%s] in namespace [%s], filtered out by namespace filter regexp [%s]", name, namespace, c.namespaceFilterRegexp)
 		return true
 	}
 	return false
@@ -267,11 +267,11 @@ func New(ctx context.Context, cfg *config.Config, kubeclientset kubernetes.Inter
 		return nil, errors.Wrapf(err, "failed to initialize resource lock.")
 	}
 	controller := &Controller{
-		metrics:          newControllerMetrics(scope),
-		recorder:         eventRecorder,
-		gc:               gc,
-		numWorkers:       cfg.Workers,
-		namespaceFilterR: namespaceFilterR,
+		metrics:               newControllerMetrics(scope),
+		recorder:              eventRecorder,
+		gc:                    gc,
+		numWorkers:            cfg.Workers,
+		namespaceFilterRegexp: namespaceFilterR,
 	}
 
 	lock, err := newResourceLock(kubeclientset.CoreV1(), kubeclientset.CoordinationV1(), eventRecorder, cfg.LeaderElection)

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -29,14 +29,14 @@ type gcMetrics struct {
 // Garbage collector is an active background cleanup service, that deletes all workflows that are completed and older
 // than the configured TTL
 type GarbageCollector struct {
-	wfClient         v1alpha1.FlyteworkflowV1alpha1Interface
-	namespaceClient  corev1.NamespaceInterface
-	ttlHours         int
-	interval         time.Duration
-	clk              clock.Clock
-	metrics          *gcMetrics
-	namespace        string
-	namespaceFilterR *regexp.Regexp
+	wfClient              v1alpha1.FlyteworkflowV1alpha1Interface
+	namespaceClient       corev1.NamespaceInterface
+	ttlHours              int
+	interval              time.Duration
+	clk                   clock.Clock
+	metrics               *gcMetrics
+	namespace             string
+	namespaceFilterRegexp *regexp.Regexp
 }
 
 // Issues a background deletion command with label selector for all completed workflows outside of the retention period
@@ -53,8 +53,8 @@ func (g *GarbageCollector) deleteWorkflows(ctx context.Context) error {
 		for _, n := range namespaceList.Items {
 			namespaceCtx := contextutils.WithNamespace(ctx, n.GetName())
 
-			if g.namespaceFilterR != nil && !g.namespaceFilterR.MatchString(n.GetName()) {
-				logger.Infof(namespaceCtx, "Skip namespace: [%s], filtered out by regexp: [%s]", n.GetName(), g.namespaceFilterR)
+			if g.namespaceFilterRegexp != nil && !g.namespaceFilterRegexp.MatchString(n.GetName()) {
+				logger.Infof(namespaceCtx, "Skip namespace: [%s], filtered out by regexp: [%s]", n.GetName(), g.namespaceFilterRegexp)
 				continue
 			}
 
@@ -148,8 +148,8 @@ func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Cl
 			gcRoundSuccess: labeled.NewCounter("gc_success", "successful executions of delete request", scope),
 			gcRoundFailure: labeled.NewCounter("gc_failure", "failure to delete workflows", scope),
 		},
-		clk:              clk,
-		namespace:        cfg.LimitNamespace,
-		namespaceFilterR: namespaceFilterR,
+		clk:                   clk,
+		namespace:             cfg.LimitNamespace,
+		namespaceFilterRegexp: namespaceFilterR,
 	}, nil
 }

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"regexp"
 	"runtime/pprof"
 	"time"
 
@@ -28,13 +29,14 @@ type gcMetrics struct {
 // Garbage collector is an active background cleanup service, that deletes all workflows that are completed and older
 // than the configured TTL
 type GarbageCollector struct {
-	wfClient        v1alpha1.FlyteworkflowV1alpha1Interface
-	namespaceClient corev1.NamespaceInterface
-	ttlHours        int
-	interval        time.Duration
-	clk             clock.Clock
-	metrics         *gcMetrics
-	namespace       string
+	wfClient         v1alpha1.FlyteworkflowV1alpha1Interface
+	namespaceClient  corev1.NamespaceInterface
+	ttlHours         int
+	interval         time.Duration
+	clk              clock.Clock
+	metrics          *gcMetrics
+	namespace        string
+	namespaceFilterR *regexp.Regexp
 }
 
 // Issues a background deletion command with label selector for all completed workflows outside of the retention period
@@ -50,6 +52,12 @@ func (g *GarbageCollector) deleteWorkflows(ctx context.Context) error {
 		}
 		for _, n := range namespaceList.Items {
 			namespaceCtx := contextutils.WithNamespace(ctx, n.GetName())
+
+			if g.namespaceFilterR != nil && !g.namespaceFilterR.MatchString(n.GetName()) {
+				logger.Infof(namespaceCtx, "Skip namespace: [%s], filtered out by regexp: [%s]", n.GetName(), g.namespaceFilterR)
+				continue
+			}
+
 			logger.Infof(namespaceCtx, "Triggering Workflow delete for namespace: [%s]", n.GetName())
 
 			if err := g.deleteWorkflowsForNamespace(n.GetName(), s); err != nil {
@@ -122,13 +130,14 @@ func (g *GarbageCollector) StartGC(ctx context.Context) error {
 	return nil
 }
 
-func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Clock, namespaceClient corev1.NamespaceInterface, wfClient v1alpha1.FlyteworkflowV1alpha1Interface, namespace string) (*GarbageCollector, error) {
+func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Clock, namespaceClient corev1.NamespaceInterface, wfClient v1alpha1.FlyteworkflowV1alpha1Interface, namespaceFilterR *regexp.Regexp) (*GarbageCollector, error) {
 	ttl := 23
 	if cfg.MaxTTLInHours < 23 {
 		ttl = cfg.MaxTTLInHours
 	} else {
 		logger.Warningf(context.TODO(), "defaulting max ttl for workflows to 23 hours, since configured duration is larger than 23 [%d]", cfg.MaxTTLInHours)
 	}
+
 	return &GarbageCollector{
 		wfClient:        wfClient,
 		ttlHours:        ttl,
@@ -139,7 +148,8 @@ func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Cl
 			gcRoundSuccess: labeled.NewCounter("gc_success", "successful executions of delete request", scope),
 			gcRoundFailure: labeled.NewCounter("gc_failure", "failure to delete workflows", scope),
 		},
-		clk:       clk,
-		namespace: namespace,
+		clk:              clk,
+		namespace:        cfg.LimitNamespace,
+		namespaceFilterR: namespaceFilterR,
 	}, nil
 }

--- a/pkg/controller/nodes/subworkflow/subworkflow_test.go
+++ b/pkg/controller/nodes/subworkflow/subworkflow_test.go
@@ -53,7 +53,10 @@ func Test_subworkflowHandler_HandleAbort(t *testing.T) {
 		nCtx.OnNodeID().Return("n1")
 		n := &coreMocks.ExecutableNode{}
 		swf.OnStartNode().Return(n)
-		nodeExec.OnAbortHandler(ctx, wf, n, "reason").Return(fmt.Errorf("err"))
+		swf.OnGetID().Return("swf")
+		nodeExec.OnAbortHandlerMatch(mock.Anything, mock.MatchedBy(func(wf v1alpha1.ExecutableWorkflow) bool {
+			return wf.GetID() == swf.GetID()
+		}), n, mock.Anything).Return(fmt.Errorf("err"))
 		assert.Error(t, s.HandleAbort(ctx, nCtx, wf, "x", "reason"))
 	})
 


### PR DESCRIPTION
# TL;DR
When watching "all" namespaces, a regexp filter can be used to narrow down the scope.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added (partially)
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
**This PR now depends on https://github.com/lyft/flytestdlib/pull/58.**

It is already possible to watch one specific namespace, however it seems not possible to watch
multiple ones according to https://github.com/kubernetes/client-go/issues/580

This PR added a new config (regexp) that will be used to ensure only workflow from interested namespace(s) is processed: informer callback and garbage collector.

This is probably the first time I wrote this much `go` code, please help me improve. Also I haven't spent much time working on `controller` test cases (which seems to be missing heavily).

## Tracking Issue
NA (will create one better context/use case is needed)

## Follow-up issue
NA