### PR TITLE
LimitNamespace is part of config

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -225,7 +225,7 @@ func New(ctx context.Context, cfg *config.Config, kubeclientset kubernetes.Inter
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create EventSink [%v], error %v", events.GetConfig(ctx).Type, err)
 	}
-	gc, err := NewGarbageCollector(cfg, scope, clock.RealClock{}, kubeclientset.CoreV1().Namespaces(), flytepropellerClientset.FlyteworkflowV1alpha1(), cfg.LimitNamespace)
+	gc, err := NewGarbageCollector(cfg, scope, clock.RealClock{}, kubeclientset.CoreV1().Namespaces(), flytepropellerClientset.FlyteworkflowV1alpha1())
 	if err != nil {
 		logger.Errorf(ctx, "failed to initialize GC for workflows")
 		return nil, errors.Wrapf(err, "failed to initialize WF GC")

--- a/pkg/controller/garbage_collector.go
+++ b/pkg/controller/garbage_collector.go
@@ -122,7 +122,7 @@ func (g *GarbageCollector) StartGC(ctx context.Context) error {
 	return nil
 }
 
-func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Clock, namespaceClient corev1.NamespaceInterface, wfClient v1alpha1.FlyteworkflowV1alpha1Interface, namespace string) (*GarbageCollector, error) {
+func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Clock, namespaceClient corev1.NamespaceInterface, wfClient v1alpha1.FlyteworkflowV1alpha1Interface) (*GarbageCollector, error) {
 	ttl := 23
 	if cfg.MaxTTLInHours < 23 {
 		ttl = cfg.MaxTTLInHours
@@ -140,6 +140,6 @@ func NewGarbageCollector(cfg *config.Config, scope promutils.Scope, clk clock.Cl
 			gcRoundFailure: labeled.NewCounter("gc_failure", "failure to delete workflows", scope),
 		},
 		clk:       clk,
-		namespace: namespace,
+		namespace: cfg.LimitNamespace,
 	}, nil
 }

--- a/pkg/controller/garbage_collector_test.go
+++ b/pkg/controller/garbage_collector_test.go
@@ -21,30 +21,33 @@ import (
 func TestNewGarbageCollector(t *testing.T) {
 	t.Run("enabled", func(t *testing.T) {
 		cfg := &config2.Config{
-			GCInterval:    config.Duration{Duration: time.Minute * 30},
-			MaxTTLInHours: 2,
+			GCInterval:     config.Duration{Duration: time.Minute * 30},
+			MaxTTLInHours:  2,
+			LimitNamespace: "flyte",
 		}
-		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), clock.NewFakeClock(time.Now()), nil, nil, "flyte")
+		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), clock.NewFakeClock(time.Now()), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 2, gc.ttlHours)
 	})
 
 	t.Run("enabledBeyond23Hours", func(t *testing.T) {
 		cfg := &config2.Config{
-			GCInterval:    config.Duration{Duration: time.Minute * 30},
-			MaxTTLInHours: 24,
+			GCInterval:     config.Duration{Duration: time.Minute * 30},
+			MaxTTLInHours:  24,
+			LimitNamespace: "flyte",
 		}
-		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), clock.NewFakeClock(time.Now()), nil, nil, "flyte")
+		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), clock.NewFakeClock(time.Now()), nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 23, gc.ttlHours)
 	})
 
 	t.Run("ttl0", func(t *testing.T) {
 		cfg := &config2.Config{
-			GCInterval:    config.Duration{Duration: time.Minute * 30},
-			MaxTTLInHours: 0,
+			GCInterval:     config.Duration{Duration: time.Minute * 30},
+			MaxTTLInHours:  0,
+			LimitNamespace: "flyte",
 		}
-		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), nil, nil, nil, "flyte")
+		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), nil, nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, gc.ttlHours)
 		assert.NoError(t, gc.StartGC(context.TODO()))
@@ -53,10 +56,11 @@ func TestNewGarbageCollector(t *testing.T) {
 
 	t.Run("ttl-1", func(t *testing.T) {
 		cfg := &config2.Config{
-			GCInterval:    config.Duration{Duration: time.Minute * 30},
-			MaxTTLInHours: -1,
+			GCInterval:     config.Duration{Duration: time.Minute * 30},
+			MaxTTLInHours:  -1,
+			LimitNamespace: "flyte",
 		}
-		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), nil, nil, nil, "flyte")
+		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), nil, nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, -1, gc.ttlHours)
 		assert.NoError(t, gc.StartGC(context.TODO()))
@@ -129,15 +133,17 @@ func TestGarbageCollector_StartGC(t *testing.T) {
 			}, nil
 		},
 	}
-	cfg := &config2.Config{
-		GCInterval:    config.Duration{Duration: time.Minute * 30},
-		MaxTTLInHours: 2,
-	}
 
 	t.Run("one-namespace", func(t *testing.T) {
+		cfg := &config2.Config{
+			GCInterval:     config.Duration{Duration: time.Minute * 30},
+			MaxTTLInHours:  2,
+			LimitNamespace: "flyte",
+		}
+
 		fakeClock := clock.NewFakeClock(b)
 		mockNamespaceInvoked = false
-		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), fakeClock, mockNamespaceClient, mockClient, "flyte")
+		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), fakeClock, mockNamespaceClient, mockClient)
 		assert.NoError(t, err)
 		wg.Add(1)
 		ctx := context.TODO()
@@ -150,9 +156,15 @@ func TestGarbageCollector_StartGC(t *testing.T) {
 	})
 
 	t.Run("all-namespace", func(t *testing.T) {
+		cfg := &config2.Config{
+			GCInterval:     config.Duration{Duration: time.Minute * 30},
+			MaxTTLInHours:  2,
+			LimitNamespace: "all",
+		}
+
 		fakeClock := clock.NewFakeClock(b)
 		mockNamespaceInvoked = false
-		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), fakeClock, mockNamespaceClient, mockClient, "all")
+		gc, err := NewGarbageCollector(cfg, promutils.NewTestScope(), fakeClock, mockNamespaceClient, mockClient)
 		assert.NoError(t, err)
 		wg.Add(2)
 		ctx := context.TODO()


### PR DESCRIPTION
# TL;DR
No need to pass one additional argument because `cfg` has it.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This is not a bug or feature. The `namespace` argument is not necessary because it is read from `cfg` and `cfg` is already an argument.

## Tracking Issue
NA

## Follow-up issue
NA