### PR TITLE
Emit error metrics for all failures

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -398,7 +398,7 @@ func (c *nodeExecutor) handleNode(ctx context.Context, w v1alpha1.ExecutableWork
 		return executors.NodeStatusFailed(fmt.Errorf(nodeStatus.GetMessage())), nil
 	}
 
-	// case v1alpha1.NodePhaseQueued, v1alpha1.NodePhaseRunning, v1alpha1.NodePhaseRetryableFailure:
+	// case v1alpha1.NodePhaseQueued, v1alpha1.NodePhaseRunning:
 	logger.Debugf(ctx, "node executing, current phase [%s]", currentPhase)
 	defer logger.Debugf(ctx, "node execution completed")
 	p, err := c.execute(ctx, h, nCtx, nodeStatus)
@@ -408,6 +408,8 @@ func (c *nodeExecutor) handleNode(ctx context.Context, w v1alpha1.ExecutableWork
 	}
 
 	execErr := p.GetErr()
+	// execErr(in phase-inf) from execute() is only available during task failures(both retryable and permanent failure) and the current phase
+	// at the time can only be v1alpha1.NodePhaseQueued or v1alpha1.NodePhaseRunning
 	if execErr != nil && nodeStatus.GetLastAttemptStartedAt() != nil {
 		if execErr.GetKind() == core.ExecutionError_SYSTEM {
 			nodeStatus.IncrementSystemFailures()

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -410,7 +410,7 @@ func (c *nodeExecutor) handleNode(ctx context.Context, w v1alpha1.ExecutableWork
 		return executors.NodeStatusUndefined, err
 	}
 
-	// execErr(in phase-inf) from execute() is only available during task failures(both retryable and permanent failure) and the current phase
+	// execErr(in phase-info) from execute() is only available during task failures(both retryable and permanent failure) and the current phase
 	// at the time can only be v1alpha1.NodePhaseRunning
 	execErr := p.GetErr()
 	if execErr != nil && currentPhase == v1alpha1.NodePhaseRunning {

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -474,6 +474,7 @@ func (c *nodeExecutor) handleNode(ctx context.Context, w v1alpha1.ExecutableWork
 			return executors.NodeStatusUndefined, errors.Wrapf(errors.EventRecordingFailed, node.GetID(), err, "failed to record node event")
 		}
 
+		// We reach here only when transitioning from Queued to Running. In this case, the startedAt is not set.
 		if np == v1alpha1.NodePhaseRunning {
 			if nodeStatus.GetQueuedAt() != nil {
 				c.metrics.QueuingLatency.Observe(ctx, nodeStatus.GetQueuedAt().Time, time.Now())

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -397,7 +397,7 @@ func (c *nodeExecutor) handleNode(ctx context.Context, w v1alpha1.ExecutableWork
 		return executors.NodeStatusFailed(fmt.Errorf(nodeStatus.GetMessage())), nil
 	}
 
-	// we reset node status inside execute for retryable failure, we use lastAttemptStartTime to carry that information
+	// Since we reset node status inside execute for retryable failure, we use lastAttemptStartTime to carry that information
 	// across execute which is used to emit metrics
 	lastAttemptStartTime := nodeStatus.GetLastAttemptStartedAt()
 
@@ -410,8 +410,8 @@ func (c *nodeExecutor) handleNode(ctx context.Context, w v1alpha1.ExecutableWork
 		return executors.NodeStatusUndefined, err
 	}
 
-	// execErr(in phase-info) from execute() is only available during task failures(both retryable and permanent failure) and the current phase
-	// at the time can only be v1alpha1.NodePhaseRunning
+	// execErr in phase-info 'p' is only available if node has failed to execute, and the current phase at that time
+	// will be v1alpha1.NodePhaseRunning
 	execErr := p.GetErr()
 	if execErr != nil && currentPhase == v1alpha1.NodePhaseRunning {
 


### PR DESCRIPTION
We found metrics not reported. On further digging, we realized, that status is cleared in the Retry case, before we were using. Also in cases, few extra checks regarding node transitions prevented metrics from getting emitted.

## Type
 - [X ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ X] Code completed
 - [ X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

