### PR TITLE
Fix exponent overflow

### DIFF
--- a/pkg/controller/nodes/task/backoff/atomic_time.go
+++ b/pkg/controller/nodes/task/backoff/atomic_time.go
@@ -5,22 +5,26 @@ import (
 	"time"
 )
 
-// AtomicTime represents an atomic.Value that stores time.Time
+// AtomicTime represents an atomic.Value that stores time.Time.
 type AtomicTime struct {
 	v atomic.Value
 }
 
+// Loads the underlying time.Time.
 func (a *AtomicTime) Load() time.Time {
 	return a.v.Load().(time.Time)
 }
 
+// Stores time.Time to the underlying atomic.Value
 func (a *AtomicTime) Store(t time.Time) {
 	a.v.Store(t)
 }
 
+// Creates a new Atomic time.Time
 func NewAtomicTime(t time.Time) AtomicTime {
 	v := atomic.Value{}
 	v.Store(t)
+
 	return AtomicTime{
 		v: v,
 	}

--- a/pkg/controller/nodes/task/backoff/atomic_time.go
+++ b/pkg/controller/nodes/task/backoff/atomic_time.go
@@ -1,0 +1,27 @@
+package backoff
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// AtomicTime represents an atomic.Value that stores time.Time
+type AtomicTime struct {
+	v atomic.Value
+}
+
+func (a *AtomicTime) Load() time.Time {
+	return a.v.Load().(time.Time)
+}
+
+func (a *AtomicTime) Store(t time.Time) {
+	a.v.Store(t)
+}
+
+func NewAtomicTime(t time.Time) AtomicTime {
+	v := atomic.Value{}
+	v.Store(t)
+	return AtomicTime{
+		v: v,
+	}
+}

--- a/pkg/controller/nodes/task/backoff/controller.go
+++ b/pkg/controller/nodes/task/backoff/controller.go
@@ -37,33 +37,16 @@ func (m *Controller) GetOrCreateHandler(ctx context.Context, key string, backOff
 	} else {
 		logger.Infof(ctx, "The back-off handler for [%v] has been created.\n", key)
 	}
+
 	if ret, casted := h.(*ComputeResourceAwareBackOffHandler); casted {
 		return ret
 	}
+
 	return nil
 }
 
 func (m *Controller) GetBackOffHandler(key string) (*ComputeResourceAwareBackOffHandler, bool) {
 	return m.backOffHandlerMap.Get(key)
-}
-
-func (m *Controller) CreateBackOffHandler(ctx context.Context, key string, backOffBaseSecond int, maxBackOffDuration time.Duration) *ComputeResourceAwareBackOffHandler {
-	m.backOffHandlerMap.Set(key, &ComputeResourceAwareBackOffHandler{
-		SimpleBackOffBlocker: &SimpleBackOffBlocker{
-			Clock:              m.Clock,
-			BackOffBaseSecond:  backOffBaseSecond,
-			BackOffExponent:    0,
-			NextEligibleTime:   m.Clock.Now(),
-			MaxBackOffDuration: maxBackOffDuration,
-		},
-		ComputeResourceCeilings: &ComputeResourceCeilings{
-			computeResourceCeilings: v1.ResourceList{},
-		},
-	})
-	h, _ := m.backOffHandlerMap.Get(key)
-	h.reset()
-	logger.Infof(ctx, "The back-off handler for [%v] has been created.\n", key)
-	return h
 }
 
 func ComposeResourceKey(o k8s.Resource) string {

--- a/pkg/controller/nodes/task/backoff/controller.go
+++ b/pkg/controller/nodes/task/backoff/controller.go
@@ -3,7 +3,6 @@ package backoff
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"time"
 
 	stdAtomic "github.com/lyft/flytestdlib/atomic"
@@ -23,14 +22,12 @@ type Controller struct {
 }
 
 func (m *Controller) GetOrCreateHandler(ctx context.Context, key string, backOffBaseSecond int, maxBackOffDuration time.Duration) *ComputeResourceAwareBackOffHandler {
-	nextEligibleTime := atomic.Value{}
-	nextEligibleTime.Store(m.Clock.Now())
 	h, loaded := m.backOffHandlerMap.LoadOrStore(key, &ComputeResourceAwareBackOffHandler{
 		SimpleBackOffBlocker: &SimpleBackOffBlocker{
 			Clock:              m.Clock,
 			BackOffBaseSecond:  backOffBaseSecond,
 			BackOffExponent:    stdAtomic.NewUint32(0),
-			NextEligibleTime:   nextEligibleTime,
+			NextEligibleTime:   NewAtomicTime(m.Clock.Now()),
 			MaxBackOffDuration: maxBackOffDuration,
 		}, ComputeResourceCeilings: &ComputeResourceCeilings{
 			computeResourceCeilings: v1.ResourceList{},

--- a/pkg/controller/nodes/task/backoff/handler.go
+++ b/pkg/controller/nodes/task/backoff/handler.go
@@ -28,19 +28,19 @@ type SimpleBackOffBlocker struct {
 	MaxBackOffDuration time.Duration
 
 	// Mutable fields
-	syncObj            sync.RWMutex
-	BackOffExponent    int
-	NextEligibleTime   time.Time
+	syncObj          sync.RWMutex
+	BackOffExponent  int
+	NextEligibleTime time.Time
 }
 
-func (b SimpleBackOffBlocker) isBlocking(t time.Time) bool {
+func (b *SimpleBackOffBlocker) isBlocking(t time.Time) bool {
 	b.syncObj.RLock()
 	defer b.syncObj.RUnlock()
 
 	return !b.NextEligibleTime.Before(t)
 }
 
-func (b SimpleBackOffBlocker) getBlockExpirationTime() time.Time {
+func (b *SimpleBackOffBlocker) getBlockExpirationTime() time.Time {
 	b.syncObj.RLock()
 	defer b.syncObj.RUnlock()
 

--- a/pkg/controller/nodes/task/backoff/handler.go
+++ b/pkg/controller/nodes/task/backoff/handler.go
@@ -5,7 +5,6 @@ import (
 	"math"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/lyft/flyteplugins/go/tasks/errors"
@@ -30,15 +29,15 @@ type SimpleBackOffBlocker struct {
 
 	// Mutable fields
 	BackOffExponent  stdAtomic.Uint32
-	NextEligibleTime atomic.Value
+	NextEligibleTime AtomicTime
 }
 
 func (b *SimpleBackOffBlocker) isBlocking(t time.Time) bool {
-	return !b.NextEligibleTime.Load().(time.Time).Before(t)
+	return !b.NextEligibleTime.Load().Before(t)
 }
 
 func (b *SimpleBackOffBlocker) getBlockExpirationTime() time.Time {
-	return b.NextEligibleTime.Load().(time.Time)
+	return b.NextEligibleTime.Load()
 }
 
 func (b *SimpleBackOffBlocker) reset() {

--- a/pkg/controller/nodes/task/backoff/handler_test.go
+++ b/pkg/controller/nodes/task/backoff/handler_test.go
@@ -475,7 +475,7 @@ func TestSimpleBackOffBlocker_backOff(t *testing.T) {
 				MaxBackOffDuration: tt.fields.MaxBackOffDuration,
 			}
 
-			if got := b.backOff(); !reflect.DeepEqual(got, tt.wantDuration) {
+			if got := b.backOff(context.Background()); !reflect.DeepEqual(got, tt.wantDuration) {
 				t.Errorf("backOff() = %v, want %v", got, tt.wantDuration)
 			}
 			if gotExp := b.BackOffExponent; !reflect.DeepEqual(gotExp.Load(), tt.wantExponent) {
@@ -494,7 +494,7 @@ func TestSimpleBackOffBlocker_backOff(t *testing.T) {
 		}
 
 		for i := 0; i < 10; i++ {
-			backOffDuration := b.backOff()
+			backOffDuration := b.backOff(context.Background())
 			assert.Equal(t, maxBackOffDuration, backOffDuration)
 			assert.Equal(t, uint32(10), b.BackOffExponent.Load())
 		}

--- a/pkg/controller/nodes/task/backoff/handler_test.go
+++ b/pkg/controller/nodes/task/backoff/handler_test.go
@@ -3,10 +3,11 @@ package backoff
 import (
 	"context"
 	"errors"
-	"github.com/magiconair/properties/assert"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/magiconair/properties/assert"
 
 	taskErrors "github.com/lyft/flyteplugins/go/tasks/errors"
 	stdlibErrors "github.com/lyft/flytestdlib/errors"

--- a/pkg/controller/nodes/task/backoff/handler_test.go
+++ b/pkg/controller/nodes/task/backoff/handler_test.go
@@ -3,6 +3,7 @@ package backoff
 import (
 	"context"
 	"errors"
+	"github.com/magiconair/properties/assert"
 	"reflect"
 	"testing"
 	"time"
@@ -450,7 +451,7 @@ func TestSimpleBackOffBlocker_backOff(t *testing.T) {
 		},
 		{name: "backoff should saturate",
 			fields:       fields{Clock: tc, BackOffBaseSecond: 2, BackOffExponent: 10, NextEligibleTime: tc.Now(), MaxBackOffDuration: maxBackOffDuration},
-			wantExponent: 11,
+			wantExponent: 10,
 			wantDuration: maxBackOffDuration,
 		},
 	}
@@ -472,4 +473,20 @@ func TestSimpleBackOffBlocker_backOff(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("backoff many times after maxBackOffDuration is hit", func(t *testing.T) {
+		b := &SimpleBackOffBlocker{
+			Clock:              tc,
+			BackOffBaseSecond:  2,
+			BackOffExponent:    10,
+			NextEligibleTime:   tc.Now(),
+			MaxBackOffDuration: maxBackOffDuration,
+		}
+
+		for i := 0; i < 10; i++ {
+			backOffDuration := b.backOff()
+			assert.Equal(t, maxBackOffDuration, backOffDuration)
+			assert.Equal(t, 10, b.BackOffExponent)
+		}
+	})
 }

--- a/pkg/controller/nodes/task/backoff/handler_test.go
+++ b/pkg/controller/nodes/task/backoff/handler_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,12 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/clock"
 )
-
-func newNextEligibleTime(t time.Time) atomic.Value {
-	v := atomic.Value{}
-	v.Store(t)
-	return v
-}
 
 func TestComputeResourceAwareBackOffHandler_Handle(t *testing.T) {
 	var callCount = 0
@@ -71,7 +64,7 @@ func TestComputeResourceAwareBackOffHandler_Handle(t *testing.T) {
 					Clock:              tc,
 					BackOffBaseSecond:  2,
 					BackOffExponent:    stdAtomic.NewUint32(1),
-					NextEligibleTime:   newNextEligibleTime(tc.Now().Add(time.Second * 7)),
+					NextEligibleTime:   NewAtomicTime(tc.Now().Add(time.Second * 7)),
 					MaxBackOffDuration: 10 * time.Second,
 				},
 				ComputeResourceCeilings: &ComputeResourceCeilings{
@@ -96,7 +89,7 @@ func TestComputeResourceAwareBackOffHandler_Handle(t *testing.T) {
 					Clock:              tc,
 					BackOffBaseSecond:  2,
 					BackOffExponent:    stdAtomic.NewUint32(1),
-					NextEligibleTime:   newNextEligibleTime(tc.Now().Add(time.Second * 7)),
+					NextEligibleTime:   NewAtomicTime(tc.Now().Add(time.Second * 7)),
 					MaxBackOffDuration: 10 * time.Second,
 				},
 				ComputeResourceCeilings: &ComputeResourceCeilings{
@@ -123,7 +116,7 @@ func TestComputeResourceAwareBackOffHandler_Handle(t *testing.T) {
 					Clock:              tc,
 					BackOffBaseSecond:  2,
 					BackOffExponent:    stdAtomic.NewUint32(1),
-					NextEligibleTime:   newNextEligibleTime(tc.Now().Add(time.Second * -2)),
+					NextEligibleTime:   NewAtomicTime(tc.Now().Add(time.Second * -2)),
 					MaxBackOffDuration: 10 * time.Second,
 				},
 				ComputeResourceCeilings: &ComputeResourceCeilings{
@@ -161,7 +154,7 @@ func TestComputeResourceAwareBackOffHandler_Handle(t *testing.T) {
 			if tt.wantExp != h.BackOffExponent.Load() {
 				t.Errorf("post-Handle() BackOffExponent = %v, wantBackOffExponent %v", h.BackOffExponent, tt.wantExp)
 			}
-			if tt.wantNextEligibleTime != h.NextEligibleTime.Load().(time.Time) {
+			if tt.wantNextEligibleTime != h.NextEligibleTime.Load() {
 				t.Errorf("post-Handle() NextEligibleTime = %v, wantNextEligibleTime %v", h.NextEligibleTime, tt.wantNextEligibleTime)
 			}
 			if !reflect.DeepEqual(h.computeResourceCeilings, tt.wantCeilings) {
@@ -471,7 +464,7 @@ func TestSimpleBackOffBlocker_backOff(t *testing.T) {
 				Clock:              tt.fields.Clock,
 				BackOffBaseSecond:  tt.fields.BackOffBaseSecond,
 				BackOffExponent:    stdAtomic.NewUint32(tt.fields.BackOffExponent),
-				NextEligibleTime:   newNextEligibleTime(tt.fields.NextEligibleTime),
+				NextEligibleTime:   NewAtomicTime(tt.fields.NextEligibleTime),
 				MaxBackOffDuration: tt.fields.MaxBackOffDuration,
 			}
 
@@ -489,7 +482,7 @@ func TestSimpleBackOffBlocker_backOff(t *testing.T) {
 			Clock:              tc,
 			BackOffBaseSecond:  2,
 			BackOffExponent:    stdAtomic.NewUint32(10),
-			NextEligibleTime:   newNextEligibleTime(tc.Now()),
+			NextEligibleTime:   NewAtomicTime(tc.Now()),
 			MaxBackOffDuration: maxBackOffDuration,
 		}
 

--- a/pkg/controller/nodes/task/k8s/plugin_manager_test.go
+++ b/pkg/controller/nodes/task/k8s/plugin_manager_test.go
@@ -343,7 +343,7 @@ func TestK8sTaskExecutor_Handle_LaunchResource(t *testing.T) {
 		refKey := backoff.ComposeResourceKey(referenceResource)
 		podBackOffHandler, found := backOffController.GetBackOffHandler(refKey)
 		assert.True(t, found)
-		assert.Equal(t, 1, podBackOffHandler.BackOffExponent)
+		assert.Equal(t, uint32(1), podBackOffHandler.BackOffExponent.Load())
 	})
 }
 


### PR DESCRIPTION
# TL;DR
Backoff controller has two issues: 1) backoff() can overflow the exponent value leading to 0 backoff duration all the time. 2) There is a race condition in updating fields of the simple backoff handler. this PR should address both.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/233
