### PR TITLE
Update to latest boilerplate and remove duplicate codecov target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,6 @@ golden:
 	go test ./cmd/kubectl-flyte/cmd -update
 	go test ./pkg/compiler/test -update
 
-.PHONY: test_unit_codecov
-test_unit_codecov:
-	go test ./... -race -coverprofile=coverage.txt -covermode=atomic
-	curl -s https://codecov.io/bash > codecov_bash.sh && bash codecov_bash.sh
-
 .PHONY: generate
 generate: download_tooling
 	@go generate ./...

--- a/boilerplate/lyft/golang_support_tools/tools.go
+++ b/boilerplate/lyft/golang_support_tools/tools.go
@@ -3,8 +3,8 @@
 package tools
 
 import (
-	_ "github.com/alvaroloes/enumer"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/lyft/flytestdlib/cli/pflags"
 	_ "github.com/vektra/mockery/cmd/mockery"
+	_ "github.com/alvaroloes/enumer"
 )

--- a/boilerplate/lyft/golang_test_targets/Makefile
+++ b/boilerplate/lyft/golang_test_targets/Makefile
@@ -39,9 +39,15 @@ test_benchmark:
 
 .PHONY: test_unit_cover
 test_unit_cover:
-	go test ./... -coverprofile /tmp/cover.out -covermode=count; go tool cover -func /tmp/cover.out
+	go test ./... -coverprofile /tmp/cover.out -covermode=count
+	go tool cover -func /tmp/cover.out
 
 .PHONY: test_unit_visual
 test_unit_visual:
-	go test ./... -coverprofile /tmp/cover.out -covermode=count; go tool cover -html=/tmp/cover.out 
-
+	go test ./... -coverprofile /tmp/cover.out -covermode=count
+	go tool cover -html=/tmp/cover.out
+	
+.PHONY: test_unit_codecov
+test_unit_codecov:
+	go test ./... -race -coverprofile=coverage.txt -covermode=atomic
+	curl -s https://codecov.io/bash > codecov_bash.sh && bash codecov_bash.sh


### PR DESCRIPTION
# TL;DR
This change removes a target from the Makefile that's been added to the boilerplate golang test target Makefile.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/lyft/flyte/issues/259

## Follow-up issue
_NA_
