### PR TITLE
Docs point to the new godocs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Flyte Propeller
 ===============
 [![Current Release](https://img.shields.io/github/release/lyft/flytepropeller.svg)](https://github.com/lyft/flytepropeller/releases/latest)
 [![Build Status](https://travis-ci.org/lyft/flytepropeller.svg?branch=master)](https://travis-ci.org/lyft/flytepropeller)
-[![GoDoc](https://godoc.org/github.com/lyft/flytepropeller?status.svg)](https://godoc.org/github.com/lyft/flytepropeller)
+[![GoDoc](https://godoc.org/github.com/lyft/flytepropeller?status.svg)](https://pkg.go.dev/mod/github.com/lyft/flytepropeller)
 [![License](https://img.shields.io/badge/LICENSE-Apache2.0-ff69b4.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![CodeCoverage](https://img.shields.io/codecov/c/github/lyft/flytepropeller.svg)](https://codecov.io/gh/lyft/flytepropeller)
 [![Go Report Card](https://goreportcard.com/badge/github.com/lyft/flytepropeller)](https://goreportcard.com/report/github.com/lyft/flytepropeller)


### PR DESCRIPTION
# TL;DR
Godocs have moved, fixing the link

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 docs were pointing to the old godoc.org, changed it to pkg.go.dev

## Tracking Issue
https://github.com/lyft/flyte/issues/258

