### PR TITLE
Revert "pass command line args"

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -94,13 +94,11 @@ func init() {
 	rootCmd.AddCommand(viper.GetConfigCommand())
 }
 
-func initConfig(cmd *cobra.Command, _ []string) error {
+func initConfig(_ *cobra.Command, _ []string) error {
 	configAccessor = viper.NewAccessor(config.Options{
 		StrictMode:  true,
 		SearchPaths: []string{cfgFile},
 	})
-
-	configAccessor.InitializePflags(cmd.Flags())
 
 	err := configAccessor.UpdateConfig(context.TODO())
 	if err != nil {


### PR DESCRIPTION
Reverts lyft/flytepropeller#63

I believe this PR is causing deploys to fail with
```
Error:
strict mode is on but received keys [map[add_dir_header:false alsologtostderr:false config:/etc/flyte/config*/config.yaml help:false log_backtrace_at::0 log_dir: log_file: log_file_max_size:1800 logtostderr:true skip_headers:false skip_log_headers:false stderrthreshold:2 v:0 vmodule:]] to decode with no config assigned to receive them: failed strict mode check
```

