### PR TITLE
[Bug Fix] Node timeout should use default value if set to zero.

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -412,7 +412,7 @@ func (c *nodeExecutor) handleQueuedOrRunningNode(ctx context.Context, nCtx *node
 
 func (c *nodeExecutor) handleRetryableFailure(ctx context.Context, nCtx *nodeExecContext, h handler.Node) (executors.NodeStatus, error) {
 	nodeStatus := nCtx.NodeStatus()
-	logger.Debugf(ctx, "node failed with retryable failure, aborting and finalizing, expectedReason: %s", nodeStatus.GetMessage())
+	logger.Debugf(ctx, "node failed with retryable failure, aborting and finalizing, message: %s", nodeStatus.GetMessage())
 	if err := c.abort(ctx, h, nCtx, nodeStatus.GetMessage()); err != nil {
 		return executors.NodeStatusUndefined, err
 	}

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -219,7 +219,7 @@ func (c *nodeExecutor) execute(ctx context.Context, h handler.Node, nCtx *nodeEx
 		}
 		if c.isTimeoutExpired(nodeStatus.GetQueuedAt(), activeDeadline) {
 			logger.Errorf(ctx, "Node has timed out; timeout configured: %v", activeDeadline)
-			return handler.PhaseInfoTimedOut(nil, fmt.Sprintf("active deadline(%v) elapsed", activeDeadline)), nil
+			return handler.PhaseInfoTimedOut(nil, fmt.Sprintf("task active timeout [%s] expired", activeDeadline.String())), nil
 		}
 
 		// Execution timeout is a retry-able error

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1284,6 +1284,7 @@ func Test_nodeExecutor_timeout(t *testing.T) {
 		executionDeadline time.Duration
 		retries           int
 		err               error
+		expectedReason    string
 	}{
 		{
 			name:              "timeout",
@@ -1292,6 +1293,16 @@ func Test_nodeExecutor_timeout(t *testing.T) {
 			activeDeadline:    time.Second * 5,
 			executionDeadline: time.Second * 5,
 			err:               nil,
+		},
+		{
+			name:              "default_execution_timeout",
+			phaseInfo:         handler.PhaseInfoRunning(nil),
+			expectedPhase:     handler.EPhaseRetryableFailure,
+			activeDeadline:    time.Second * 50,
+			executionDeadline: 0,
+			retries:           2,
+			err:               nil,
+			expectedReason:    "Node has timed out; timeout configured: 5s",
 		},
 		{
 			name:              "retryable-failure",
@@ -1348,7 +1359,7 @@ func Test_nodeExecutor_timeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &nodeExecutor{}
+			c := &nodeExecutor{defaultActiveDeadline: time.Second, defaultExecutionDeadline: time.Second}
 			handlerReturn := func() (handler.Transition, error) {
 				return handler.DoTransition(handler.TransitionTypeEphemeral, tt.phaseInfo), tt.err
 			}
@@ -1384,6 +1395,9 @@ func Test_nodeExecutor_timeout(t *testing.T) {
 				assert.NoError(t, err)
 			}
 			assert.Equal(t, tt.expectedPhase.String(), phaseInfo.GetPhase().String())
+			if tt.expectedReason != "" {
+				assert.Equal(t, tt.expectedReason, phaseInfo.GetReason())
+			}
 		})
 	}
 }

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -1302,7 +1302,7 @@ func Test_nodeExecutor_timeout(t *testing.T) {
 			executionDeadline: 0,
 			retries:           2,
 			err:               nil,
-			expectedReason:    "Node has timed out; timeout configured: 5s",
+			expectedReason:    "task execution timeout [1s] expired",
 		},
 		{
 			name:              "retryable-failure",

--- a/pkg/controller/nodes/handler/transition_info.go
+++ b/pkg/controller/nodes/handler/transition_info.go
@@ -148,7 +148,7 @@ func phaseInfoFailed(p EPhase, err *core.ExecutionError, info *ExecutionInfo) Ph
 			Message: "Unknown error message",
 		}
 	}
-	return phaseInfo(p, err, info, "")
+	return phaseInfo(p, err, info, err.Message)
 }
 
 func PhaseInfoFailure(code, reason string, info *ExecutionInfo) PhaseInfo {


### PR DESCRIPTION
# TL;DR
Default node timeout was not being correctly applied to the cases where node timeout specified in CRD was 0.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/289