### PR TITLE
Nullable field handling in CRD

### DIFF
--- a/pkg/apis/flyteworkflow/v1alpha1/error.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/error.go
@@ -18,6 +18,9 @@ func (in *ExecutionError) UnmarshalJSON(b []byte) error {
 }
 
 func (in *ExecutionError) MarshalJSON() ([]byte, error) {
+	if in == nil {
+		return []byte{}, nil
+	}
 	var buf bytes.Buffer
 	if err := marshaler.Marshal(&buf, in.ExecutionError); err != nil {
 		return nil, err

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -128,7 +128,9 @@ func (in *DynamicNodeStatus) SetDynamicNodePhase(phase DynamicNodePhase) {
 }
 
 func (in *DynamicNodeStatus) SetExecutionError(err *core.ExecutionError) {
-	in.Error = &ExecutionError{ExecutionError: err}
+	if err != nil {
+		in.Error = &ExecutionError{ExecutionError: err}
+	}
 }
 
 func (in *DynamicNodeStatus) Equals(o *DynamicNodeStatus) bool {

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -131,6 +131,7 @@ func (in *DynamicNodeStatus) SetExecutionError(err *core.ExecutionError) {
 	if err != nil {
 		in.Error = &ExecutionError{ExecutionError: err}
 	}
+	in.Error = nil
 }
 
 func (in *DynamicNodeStatus) Equals(o *DynamicNodeStatus) bool {

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status.go
@@ -130,8 +130,9 @@ func (in *DynamicNodeStatus) SetDynamicNodePhase(phase DynamicNodePhase) {
 func (in *DynamicNodeStatus) SetExecutionError(err *core.ExecutionError) {
 	if err != nil {
 		in.Error = &ExecutionError{ExecutionError: err}
+	} else {
+		in.Error = nil
 	}
-	in.Error = nil
 }
 
 func (in *DynamicNodeStatus) Equals(o *DynamicNodeStatus) bool {

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -162,4 +163,33 @@ func TestWorkflowStatus_Deserialize(t *testing.T) {
 	parsed := &NodeStatus{}
 	err := json.Unmarshal(raw, parsed)
 	assert.NoError(t, err)
+}
+
+func TestDynamicNodeStatus_SetExecutionError(t *testing.T) {
+	type args struct {
+		err *core.ExecutionError
+	}
+	tests := []struct {
+		name     string
+		Error    *ExecutionError
+		NewError *core.ExecutionError
+	}{
+		{"preset", &ExecutionError{}, nil},
+		{"preset-new", &ExecutionError{}, &core.ExecutionError{}},
+		{"new", nil, &core.ExecutionError{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := &DynamicNodeStatus{
+				Error: tt.Error,
+			}
+			in.SetExecutionError(tt.NewError)
+			if tt.NewError == nil {
+				assert.Nil(t, in.Error)
+			} else {
+				assert.NotNil(t, in.Error)
+				assert.Equal(t, tt.NewError, in.Error.ExecutionError)
+			}
+		})
+	}
 }

--- a/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
+++ b/pkg/apis/flyteworkflow/v1alpha1/node_status_test.go
@@ -166,9 +166,6 @@ func TestWorkflowStatus_Deserialize(t *testing.T) {
 }
 
 func TestDynamicNodeStatus_SetExecutionError(t *testing.T) {
-	type args struct {
-		err *core.ExecutionError
-	}
 	tests := []struct {
 		name     string
 		Error    *ExecutionError


### PR DESCRIPTION
# TL;DR
ExecutionError is a nullable field. JSON marshal does not work with null values. This fix addresses this problem

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
NA

## Tracking Issue
https://github.com/lyft/flyte/issues/300
## Follow-up issue
NA

