### PR TITLE
Bug; Abort should propagate for Failing nodes too

### DIFF
--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -459,7 +459,11 @@ func (c *nodeExecutor) handleNode(ctx context.Context, dag executors.DAGStructur
 
 	if currentPhase == v1alpha1.NodePhaseFailing {
 		logger.Debugf(ctx, "node failing")
-		if err := c.finalize(ctx, h, nCtx); err != nil {
+		msg := "[Node failed] Unknown error"
+		if nodeStatus.GetExecutionError() != nil {
+			msg = fmt.Sprintf("[%s|%s]: %s", nodeStatus.GetExecutionError().Kind.String(), nodeStatus.GetExecutionError().Code, nodeStatus.GetExecutionError().GetMessage())
+		}
+		if err := c.abort(ctx, h, nCtx, msg); err != nil {
 			return executors.NodeStatusUndefined, err
 		}
 		nodeStatus.UpdatePhase(v1alpha1.NodePhaseFailed, v1.Now(), nodeStatus.GetMessage(), nodeStatus.GetExecutionError())


### PR DESCRIPTION
# TL;DR
This seems counter-intiuitive, but dynamic nodes are otherwise left in "Running" state when the child tasks fails

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
NA

## Tracking Issue
https://github.com/lyft/flyte/issues/309

## Follow-up issue
NA
