### PR TITLE
Update config.yaml to conform with the revised SageMaker official document

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -65,10 +65,10 @@ plugins:
         regionalConfigs:
           - region: "us-east-1"
             versionConfigs:
-              - version: 0.72
-                image: "811284229777.dkr.ecr.us-east-1.amazonaws.com/xgboost:latest"
               - version: 0.90
-                image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/xgboost:latest"
+                image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:0.90-2-cpu-py3"
+              - version: 1.0
+                image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.0-1-cpu-py3"
   # Logging configuration
   logs:
     kubernetes-enabled: true

--- a/config.yaml
+++ b/config.yaml
@@ -61,7 +61,7 @@ plugins:
     roleArn: "arn:aws:iam::123456789012:role/test-development"
     region: "us-east-1"
     prebuiltAlgorithms:
-      - name: xgboost
+      - name: "XGBOOST"
         regionalConfigs:
           - region: "us-east-1"
             versionConfigs:

--- a/config.yaml
+++ b/config.yaml
@@ -65,9 +65,9 @@ plugins:
         regionalConfigs:
           - region: "us-east-1"
             versionConfigs:
-              - version: 0.90
+              - version: "0.90"
                 image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:0.90-2-cpu-py3"
-              - version: 1.0
+              - version: "1.0"
                 image: "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.0-1-cpu-py3"
   # Logging configuration
   logs:


### PR DESCRIPTION
# TL;DR
Update config.yaml to conform with the revised SageMaker official document

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The SageMaker official document has been revised to recommend against the use of image tag `:latest` and `:1` for XGBoost, and has deprecated XGBoost 0.72 and the changed the image name from `xgboost` to `sagemaker-xgboost`. This PR updates the config file to conform with the official changes.

![image](https://user-images.githubusercontent.com/1518524/89614102-9652d300-d838-11ea-9742-fa6ead626535.png)


## Tracking Issue


## Follow-up issue
_NA_

