### PR TITLE
Add TaskExecutionMetadata to TaskExecutionEvent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/lyft/datacatalog v0.2.1
-	github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960
+	github.com/lyft/flyteidl v0.18.7
 	github.com/lyft/flyteplugins v0.5.1
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/lyft/datacatalog v0.2.1
-	github.com/lyft/flyteidl v0.18.6
+	github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960
 	github.com/lyft/flyteplugins v0.5.1
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -397,10 +397,9 @@ github.com/lyft/datacatalog v0.2.1 h1:W7LsAjaS297iLCtSH9ZaAAG3YPofwkbbgIaqkfdeM0
 github.com/lyft/datacatalog v0.2.1/go.mod h1:ktrPvzTDUwHO5Lv0hLH38zLHnOJ++rGoAO0iQ/sIPJ4=
 github.com/lyft/flyteidl v0.17.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteidl v0.18.1 h1:COKkZi5k6bQvUYOk5gE70+FJX9/NUn0WOQ1uMrw3Qio=
-github.com/lyft/flyteidl v0.18.1/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteidl v0.18.6 h1:HGbxHI8avEDvoPqcO2+/BoJVcP9sjOj4qwJ/wNRWuoA=
 github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960 h1:1A5aOwZcnrMJyYE3ilUbmUcrmcAEEQ/n1m+iPO41Jws=
+github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteplugins v0.4.7-0.20200904001213-41861229003a h1:NcURTOidN/PUOMRSKvaKMJmSdGcdLJHPwZFmpSX+KVk=
 github.com/lyft/flyteplugins v0.4.7-0.20200904001213-41861229003a/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flyteplugins v0.4.8 h1:fGihSTfOw1LEGuwh7QfRp3l2dT28DfGFAu2d0axr8Q4=

--- a/go.sum
+++ b/go.sum
@@ -397,14 +397,8 @@ github.com/lyft/datacatalog v0.2.1 h1:W7LsAjaS297iLCtSH9ZaAAG3YPofwkbbgIaqkfdeM0
 github.com/lyft/datacatalog v0.2.1/go.mod h1:ktrPvzTDUwHO5Lv0hLH38zLHnOJ++rGoAO0iQ/sIPJ4=
 github.com/lyft/flyteidl v0.17.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960 h1:1A5aOwZcnrMJyYE3ilUbmUcrmcAEEQ/n1m+iPO41Jws=
-github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.7 h1:R8gSt2Tze9BlHbFHZPDPWl630272US+MbSjqoeVkflg=
 github.com/lyft/flyteidl v0.18.7/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteplugins v0.4.7-0.20200904001213-41861229003a h1:NcURTOidN/PUOMRSKvaKMJmSdGcdLJHPwZFmpSX+KVk=
-github.com/lyft/flyteplugins v0.4.7-0.20200904001213-41861229003a/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
-github.com/lyft/flyteplugins v0.4.8 h1:fGihSTfOw1LEGuwh7QfRp3l2dT28DfGFAu2d0axr8Q4=
-github.com/lyft/flyteplugins v0.4.8/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flyteplugins v0.5.1 h1:76FpQFohLCy4Eo490sES2empRAi31DJiERfbOSV9pCg=
 github.com/lyft/flyteplugins v0.5.1/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flytestdlib v0.3.0/go.mod h1:LJPPJlkFj+wwVWMrQT3K5JZgNhZi2mULsCG4ZYhinhU=

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,7 @@ github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/
 github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960 h1:1A5aOwZcnrMJyYE3ilUbmUcrmcAEEQ/n1m+iPO41Jws=
 github.com/lyft/flyteidl v0.18.7-0.20200923210508-5e52ea4ac960/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.7/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteplugins v0.4.7-0.20200904001213-41861229003a h1:NcURTOidN/PUOMRSKvaKMJmSdGcdLJHPwZFmpSX+KVk=
 github.com/lyft/flyteplugins v0.4.7-0.20200904001213-41861229003a/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flyteplugins v0.4.8 h1:fGihSTfOw1LEGuwh7QfRp3l2dT28DfGFAu2d0axr8Q4=

--- a/pkg/controller/nodes/task/handler_test.go
+++ b/pkg/controller/nodes/task/handler_test.go
@@ -359,6 +359,7 @@ func Test_task_Handle_NoCatalog(t *testing.T) {
 			Kind: "sample",
 			Name: "name",
 		})
+		nm.OnIsInterruptible().Return(false)
 
 		tk := &core.TaskTemplate{
 			Id:   &core.Identifier{ResourceType: core.ResourceType_TASK, Project: "proj", Domain: "dom", Version: "ver"},
@@ -680,6 +681,7 @@ func Test_task_Handle_Catalog(t *testing.T) {
 			Kind: "sample",
 			Name: "name",
 		})
+		nm.OnIsInterruptible().Return(true)
 
 		taskID := &core.Identifier{}
 		tk := &core.TaskTemplate{
@@ -902,6 +904,7 @@ func Test_task_Handle_Barrier(t *testing.T) {
 			Kind: "sample",
 			Name: "name",
 		})
+		nm.OnIsInterruptible().Return(true)
 
 		taskID := &core.Identifier{}
 		tk := &core.TaskTemplate{

--- a/pkg/controller/nodes/task/transformer.go
+++ b/pkg/controller/nodes/task/transformer.go
@@ -92,9 +92,9 @@ func ToTaskExecutionEvent(taskExecID *core.TaskExecutionIdentifier, in io.InputF
 	}
 
 	if nodeExecutionMetadata.IsInterruptible() {
-		tev.Metadata = &event.TaskExecutionMetadata{InstanceType: event.TaskExecutionMetadata_INTERRUPTIBLE}
+		tev.Metadata = &event.TaskExecutionMetadata{InstanceClass: event.TaskExecutionMetadata_INTERRUPTIBLE}
 	} else {
-		tev.Metadata = &event.TaskExecutionMetadata{InstanceType: event.TaskExecutionMetadata_DEFAULT}
+		tev.Metadata = &event.TaskExecutionMetadata{InstanceClass: event.TaskExecutionMetadata_DEFAULT}
 	}
 
 	return tev, nil

--- a/pkg/controller/nodes/task/transformer.go
+++ b/pkg/controller/nodes/task/transformer.go
@@ -50,7 +50,8 @@ func trimErrorMessage(original string, maxLength int) string {
 	return original[0:maxLength/2] + original[len(original)-maxLength/2:]
 }
 
-func ToTaskExecutionEvent(taskExecID *core.TaskExecutionIdentifier, in io.InputFilePaths, out io.OutputFilePaths, info pluginCore.PhaseInfo) (*event.TaskExecutionEvent, error) {
+func ToTaskExecutionEvent(taskExecID *core.TaskExecutionIdentifier, in io.InputFilePaths, out io.OutputFilePaths, info pluginCore.PhaseInfo,
+	nodeExecutionMetadata handler.NodeExecutionMetadata) (*event.TaskExecutionEvent, error) {
 	// Transitions to a new phase
 
 	tm := ptypes.TimestampNow()
@@ -88,6 +89,12 @@ func ToTaskExecutionEvent(taskExecID *core.TaskExecutionIdentifier, in io.InputF
 	if info.Info() != nil {
 		tev.Logs = info.Info().Logs
 		tev.CustomInfo = info.Info().CustomInfo
+	}
+
+	if nodeExecutionMetadata.IsInterruptible() {
+		tev.Metadata = &event.TaskExecutionMetadata{InstanceType: event.TaskExecutionMetadata_INTERRUPTIBLE}
+	} else {
+		tev.Metadata = &event.TaskExecutionMetadata{InstanceType: event.TaskExecutionMetadata_DEFAULT}
 	}
 
 	return tev, nil

--- a/pkg/controller/nodes/task/transformer_test.go
+++ b/pkg/controller/nodes/task/transformer_test.go
@@ -84,7 +84,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, nodeID, tev.ParentNodeExecutionId)
 	assert.Equal(t, inputPath, tev.InputUri)
 	assert.Nil(t, tev.OutputResult)
-	assert.Equal(t, event.TaskExecutionMetadata_INTERRUPTIBLE, tev.Metadata.InstanceType)
+	assert.Equal(t, event.TaskExecutionMetadata_INTERRUPTIBLE, tev.Metadata.InstanceClass)
 
 	l := []*core.TaskLog{
 		{Uri: "x", Name: "y", MessageFormat: core.TaskLog_JSON},
@@ -105,7 +105,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, nodeID, tev.ParentNodeExecutionId)
 	assert.Equal(t, inputPath, tev.InputUri)
 	assert.Nil(t, tev.OutputResult)
-	assert.Equal(t, event.TaskExecutionMetadata_INTERRUPTIBLE, tev.Metadata.InstanceType)
+	assert.Equal(t, event.TaskExecutionMetadata_INTERRUPTIBLE, tev.Metadata.InstanceClass)
 
 	defaultNodeExecutionMetadata := handlerMocks.NodeExecutionMetadata{}
 	defaultNodeExecutionMetadata.OnIsInterruptible().Return(false)
@@ -126,7 +126,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.NotNil(t, tev.OutputResult)
 	assert.Equal(t, inputPath, tev.InputUri)
 	assert.Equal(t, outputPath, tev.GetOutputUri())
-	assert.Empty(t, event.TaskExecutionMetadata_DEFAULT, tev.Metadata.InstanceType)
+	assert.Empty(t, event.TaskExecutionMetadata_DEFAULT, tev.Metadata.InstanceClass)
 }
 
 func TestToTransitionType(t *testing.T) {

--- a/pkg/controller/nodes/task/transformer_test.go
+++ b/pkg/controller/nodes/task/transformer_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/event"
+
 	"github.com/golang/protobuf/ptypes"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
@@ -13,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/lyft/flytepropeller/pkg/controller/nodes/handler"
+	handlerMocks "github.com/lyft/flytepropeller/pkg/controller/nodes/handler/mocks"
 )
 
 func TestToTaskEventPhase(t *testing.T) {
@@ -68,7 +71,10 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	const outputPath = "out"
 	out.On("GetOutputPath").Return(storage.DataReference(outputPath))
 
-	tev, err := ToTaskExecutionEvent(id, in, out, pluginCore.PhaseInfoWaitingForResources(n, 0, "reason"))
+	nodeExecutionMetadata := handlerMocks.NodeExecutionMetadata{}
+	nodeExecutionMetadata.OnIsInterruptible().Return(true)
+	tev, err := ToTaskExecutionEvent(id, in, out, pluginCore.PhaseInfoWaitingForResources(n, 0, "reason"),
+		&nodeExecutionMetadata)
 	assert.NoError(t, err)
 	assert.Nil(t, tev.Logs)
 	assert.Equal(t, core.TaskExecution_WAITING_FOR_RESOURCES, tev.Phase)
@@ -78,6 +84,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, nodeID, tev.ParentNodeExecutionId)
 	assert.Equal(t, inputPath, tev.InputUri)
 	assert.Nil(t, tev.OutputResult)
+	assert.Equal(t, event.TaskExecutionMetadata_INTERRUPTIBLE, tev.Metadata.InstanceType)
 
 	l := []*core.TaskLog{
 		{Uri: "x", Name: "y", MessageFormat: core.TaskLog_JSON},
@@ -87,7 +94,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 		OccurredAt: &n,
 		Logs:       l,
 		CustomInfo: c,
-	}))
+	}), &nodeExecutionMetadata)
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_RUNNING, tev.Phase)
 	assert.Equal(t, uint32(1), tev.PhaseVersion)
@@ -98,12 +105,15 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.Equal(t, nodeID, tev.ParentNodeExecutionId)
 	assert.Equal(t, inputPath, tev.InputUri)
 	assert.Nil(t, tev.OutputResult)
+	assert.Equal(t, event.TaskExecutionMetadata_INTERRUPTIBLE, tev.Metadata.InstanceType)
 
+	defaultNodeExecutionMetadata := handlerMocks.NodeExecutionMetadata{}
+	defaultNodeExecutionMetadata.OnIsInterruptible().Return(false)
 	tev, err = ToTaskExecutionEvent(id, in, out, pluginCore.PhaseInfoSuccess(&pluginCore.TaskInfo{
 		OccurredAt: &n,
 		Logs:       l,
 		CustomInfo: c,
-	}))
+	}), &defaultNodeExecutionMetadata)
 	assert.NoError(t, err)
 	assert.Equal(t, core.TaskExecution_SUCCEEDED, tev.Phase)
 	assert.Equal(t, uint32(0), tev.PhaseVersion)
@@ -116,6 +126,7 @@ func TestToTaskExecutionEvent(t *testing.T) {
 	assert.NotNil(t, tev.OutputResult)
 	assert.Equal(t, inputPath, tev.InputUri)
 	assert.Equal(t, outputPath, tev.GetOutputUri())
+	assert.Empty(t, event.TaskExecutionMetadata_DEFAULT, tev.Metadata.InstanceType)
 }
 
 func TestToTransitionType(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Add TaskExecutionMetadata to TaskExecutionEvent. At this point this only captures whether a task on a spot node or not.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://docs.google.com/document/d/1nqAp5-DanklNvG6OeQ3uIacZYGvf0oXioz7CboP_CsU/edit

## Tracking Issue
https://github.com/lyft/flyte/issues/520

## Follow-up issue
_NA_
