### PR TITLE
[Github workflows] Use latest boilerplate

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,16 +6,65 @@ on:
       - master
 
 jobs:
+  # Duplicated from pull request workflow because sharing is not yet supported
+  build-docker:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+          restore-keys: |
+            /tmp/docker-images-${{ github.event.before }}
+            /tmp/docker-images-${{ github.event.pull_request.base.sha }}
+      - name: Prime docker cache
+        run: (docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true) && (docker load -i /tmp/tmp/docker-images/snapshot.tar || true)
+      - name: Build dockerfile
+        run: |
+          docker build -t lyft/${{ github.event.repository.name }}:builder --target builder --cache-from=lyft/${{ github.event.repository.name }}:builder .
+          docker build -t lyft/${{ github.event.repository.name }}:latest --cache-from=lyft/${{ github.event.repository.name }}:builder .
+
+      - name: Tag and cache docker image
+        run: mkdir -p /tmp/tmp/docker-images && docker save lyft/${{ github.event.repository.name }}:builder -o /tmp/tmp/docker-images/snapshot-builder.tar && docker save lyft/${{ github.event.repository.name }}:latest -o /tmp/tmp/docker-images/snapshot.tar
+
+  # Duplicated from pull request workflow because sharing is not yet supported
+  endtoend:
+    name: End to End tests
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+      - name: Prime docker cache
+        run: docker load -i /tmp/tmp/docker-images/snapshot.tar || true
+      - uses: engineerd/setup-kind@v0.4.0
+      - name: End2End
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
+
   bump-version:
+    name: Bump Version
     if: github.actor != 'goreleaserbot'
     runs-on: ubuntu-latest
+    needs: build-docker # Only to ensure it can successfully build
     outputs:
       version: ${{ steps.bump-version.outputs.tag }}
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
@@ -26,57 +75,48 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
+
   goreleaser:
+    name: Goreleaser
     runs-on: ubuntu-latest
     needs: [bump-version]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-      -
-        name: Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.14
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
-  push-github-end2end:
+
+  push-github:
+    name: Push to Github Registry
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'
-      - id: cache-docker
-        uses: actions/cache@v1
+      - name: Push Docker Image to Github Registry
+        uses: whoan/docker-build-with-cache-action@v5
         with:
-          path: /tmp//tmp/docker-images
-          key: /tmp/docker-images-${{ hashFiles('Dockerfile') }}
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+          image_name: ${{ github.repository }}/${{ github.event.repository.name }}
+          image_tag: latest,${{ github.sha }},${{ needs.bump-version.outputs.version }}
+          push_git_tag: true
+          registry: docker.pkg.github.com
+          build_extra_args: "--compress=true"
 
-      - run: docker load -i /tmp//tmp/docker-images/snapshot-builder.tar || true
-        if: steps.cache-docker.outputs.cache-hit == 'true'      
-      - run: |
-          docker build -t lyft/flytepropeller:${{ github.sha }} . --target builder --cache-from=flytepropeller-cache
-          docker build -t lyft/flytepropeller:${{ github.sha }} .
-
-      - run: docker tag lyft/flytepropeller:${{ github.sha }} flytepropeller-cache && mkdir -p /tmp//tmp/docker-images && docker save flytepropeller-cache -o /tmp//tmp/docker-images/snapshot.tar && ls -lh /tmp//tmp/docker-images || true
-        if: always() && steps.cache-docker.outputs.cache-hit != 'true'
-
-      - uses: engineerd/setup-kind@v0.4.0
-      - name: End2End
-        run: |
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" $(kubectl config current-context)
-          echo "environment-kubeconfig:" ${KUBECONFIG}
-          PROPELLER=lyft/flytepropeller:${{ github.sha }} make end2end_execute
   push-dockerhub:
+    name: Push to Dockerhub
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -92,7 +132,9 @@ jobs:
           image_tag: latest,${{ github.sha }},${{ needs.bump-version.outputs.version }}
           push_git_tag: true
           build_extra_args: "--compress=true"
+
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,10 +7,15 @@ on:
 
 jobs:
   bump-version:
+    if: github.actor != 'goreleaserbot'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.bump-version.outputs.tag }}
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - uses: actions/checkout@v2
         with:
           fetch-depth: '0'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,6 +54,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
 
   integration:
+    name: Integration tests
     runs-on: ubuntu-latest
     needs: [build-docker]
     steps:
@@ -76,6 +78,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:builder make k8s_integration_execute
 
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,25 +4,45 @@ on:
   pull_request
 
 jobs:
-  build-and-end2end:
+  build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        name: "Checkout"
-      - id: cache-docker
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
         uses: actions/cache@v1
         with:
-          path: /tmp//tmp/docker-images
-          key: /tmp/docker-images-${{ hashFiles('Dockerfile') }}
-      - run: docker load -i /tmp//tmp/docker-images/snapshot-builder.tar || true
-        if: steps.cache-docker.outputs.cache-hit == 'true'
-      - run: |
-          docker build -t lyft/flytepropeller:${{ github.sha }} . --target builder --cache-from=flytepropeller-cache
-          docker build -t lyft/flytepropeller:${{ github.sha }} .
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+          restore-keys: |
+            /tmp/docker-images-${{ github.event.before }}
+            /tmp/docker-images-${{ github.event.pull_request.base.sha }}
+      - name: Prime docker cache
+        run: (docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true) && (docker load -i /tmp/tmp/docker-images/snapshot.tar || true)
+      - name: Build dockerfile
+        run: |
+          docker build -t lyft/${{ github.event.repository.name }}:builder --target builder --cache-from=lyft/${{ github.event.repository.name }}:builder .
+          docker build -t lyft/${{ github.event.repository.name }}:latest --cache-from=lyft/${{ github.event.repository.name }}:builder .
 
-      - run: docker tag lyft/flytepropeller:${{ github.sha }} flytepropeller-cache && mkdir -p /tmp//tmp/docker-images && docker save flytepropeller-cache -o /tmp//tmp/docker-images/snapshot.tar && ls -lh /tmp//tmp/docker-images || true
-        if: always() && steps.cache-docker.outputs.cache-hit != 'true'
+      - name: Tag and cache docker image
+        run: mkdir -p /tmp/tmp/docker-images && docker save lyft/${{ github.event.repository.name }}:builder -o /tmp/tmp/docker-images/snapshot-builder.tar && docker save lyft/${{ github.event.repository.name }}:latest -o /tmp/tmp/docker-images/snapshot.tar
 
+  endtoend:
+    name: End to End tests
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+      - name: Prime docker cache
+        run: docker load -i /tmp/tmp/docker-images/snapshot.tar || true
       - uses: engineerd/setup-kind@v0.4.0
       - name: End2End
         run: |
@@ -30,12 +50,36 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-          PROPELLER=lyft/flytepropeller:${{ github.sha }} make end2end_execute
+          IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+      - name: Prime docker cache
+        run: docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true
+      - uses: engineerd/setup-kind@v0.4.0
+      - name: Integration
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:builder make k8s_integration_execute
 
   tests-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Unit Tests
         uses: cedrickring/golang-action@1.5.2
         env:

--- a/boilerplate/lyft/end2end/Makefile
+++ b/boilerplate/lyft/end2end/Makefile
@@ -6,3 +6,7 @@
 .PHONY: end2end_execute
 end2end_execute:
 	./boilerplate/lyft/end2end/end2end.sh
+
+.PHONY: k8s_integration_execute
+k8s_integration_execute::
+	echo "pass"

--- a/boilerplate/lyft/github_workflows/master.yml
+++ b/boilerplate/lyft/github_workflows/master.yml
@@ -6,11 +6,68 @@ on:
       - master
 
 jobs:
-  bump-version:
+  # Duplicated from pull request workflow because sharing is not yet supported
+  build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+          restore-keys: |
+            /tmp/docker-images-${{ github.event.before }}
+            /tmp/docker-images-${{ github.event.pull_request.base.sha }}
+      - name: Prime docker cache
+        run: (docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true) && (docker load -i /tmp/tmp/docker-images/snapshot.tar || true)
+      - name: Build dockerfile
+        run: |
+          docker build -t lyft/${{ github.event.repository.name }}:builder --target builder --cache-from=lyft/${{ github.event.repository.name }}:builder .
+          docker build -t lyft/${{ github.event.repository.name }}:latest --cache-from=lyft/${{ github.event.repository.name }}:builder .
+
+      - name: Tag and cache docker image
+        run: mkdir -p /tmp/tmp/docker-images && docker save lyft/${{ github.event.repository.name }}:builder -o /tmp/tmp/docker-images/snapshot-builder.tar && docker save lyft/${{ github.event.repository.name }}:latest -o /tmp/tmp/docker-images/snapshot.tar
+
+  # Duplicated from pull request workflow because sharing is not yet supported
+  endtoend:
+    name: End to End tests
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+      - name: Prime docker cache
+        run: docker load -i /tmp/tmp/docker-images/snapshot.tar || true
+      - uses: engineerd/setup-kind@v0.4.0
+      - name: End2End
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
+
+  bump-version:
+    name: Bump Version
+    if: github.actor != 'goreleaserbot'
+    runs-on: ubuntu-latest
+    needs: build-docker # Only to ensure it can successfully build
     outputs:
       version: ${{ steps.bump-version.outputs.tag }}
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
       - name: Bump version and push tag
         id: bump-version
         uses: anothrNick/github-tag-action@1.17.2
@@ -18,7 +75,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
-  push-github-end2end:
+
+  goreleaser:
+    name: Goreleaser
+    runs-on: ubuntu-latest
+    needs: [bump-version]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GORELEASER_TOKEN }}
+
+  push-github:
+    name: Push to Github Registry
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -30,23 +109,14 @@ jobs:
         with:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.flytegithub_repo }}/operator
+          image_name: ${{ github.repository }}/${{ github.event.repository.name }}
           image_tag: latest,${{ github.sha }},${{ needs.bump-version.outputs.version }}
           push_git_tag: true
           registry: docker.pkg.github.com
           build_extra_args: "--compress=true"
-      - uses: engineerd/setup-kind@v0.4.0
-      - name: End2End
-        env:
-          DOCKER_USERNAME: ${{ github.actor }}
-          DOCKER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
-        run: |
-          kubectl cluster-info
-          kubectl get pods -n kube-system
-          echo "current-context:" $(kubectl config current-context)
-          echo "environment-kubeconfig:" ${KUBECONFIG}
-          PROPELLER=${{ secrets.flytegithub_repo }}/operator:${{ github.sha }} make end2end_execute
+
   push-dockerhub:
+    name: Push to Dockerhub
     runs-on: ubuntu-latest
     needs: bump-version
     steps:
@@ -62,7 +132,9 @@ jobs:
           image_tag: latest,${{ github.sha }},${{ needs.bump-version.outputs.version }}
           push_git_tag: true
           build_extra_args: "--compress=true"
+
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/boilerplate/lyft/github_workflows/pull_request.yml
+++ b/boilerplate/lyft/github_workflows/pull_request.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   build-docker:
+    name: Build Docker Image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -53,6 +54,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
 
   integration:
+    name: Integration tests
     runs-on: ubuntu-latest
     needs: [build-docker]
     steps:
@@ -76,6 +78,7 @@ jobs:
           IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:builder make k8s_integration_execute
 
   tests-lint:
+    name: Run tests and lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/boilerplate/lyft/github_workflows/pull_request.yml
+++ b/boilerplate/lyft/github_workflows/pull_request.yml
@@ -4,47 +4,82 @@ on:
   pull_request
 
 jobs:
-  build-and-end2end:
+  build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Push Docker Image to Github Registry
-        uses: whoan/docker-build-with-cache-action@v5
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
         with:
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.flytegithub_repo }}/flytepropeller
-          image_tag: ${{ github.sha }}
-          push_git_tag: true
-          registry: docker.pkg.github.com
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+          restore-keys: |
+            /tmp/docker-images-${{ github.event.before }}
+            /tmp/docker-images-${{ github.event.pull_request.base.sha }}
+      - name: Prime docker cache
+        run: (docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true) && (docker load -i /tmp/tmp/docker-images/snapshot.tar || true)
+      - name: Build dockerfile
+        run: |
+          docker build -t lyft/${{ github.event.repository.name }}:builder --target builder --cache-from=lyft/${{ github.event.repository.name }}:builder .
+          docker build -t lyft/${{ github.event.repository.name }}:latest --cache-from=lyft/${{ github.event.repository.name }}:builder .
+
+      - name: Tag and cache docker image
+        run: mkdir -p /tmp/tmp/docker-images && docker save lyft/${{ github.event.repository.name }}:builder -o /tmp/tmp/docker-images/snapshot-builder.tar && docker save lyft/${{ github.event.repository.name }}:latest -o /tmp/tmp/docker-images/snapshot.tar
+
+  endtoend:
+    name: End to End tests
+    runs-on: ubuntu-latest
+    needs: [build-docker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
+        with:
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+      - name: Prime docker cache
+        run: docker load -i /tmp/tmp/docker-images/snapshot.tar || true
       - uses: engineerd/setup-kind@v0.4.0
       - name: End2End
-        env:
-          DOCKER_USERNAME: ${{ github.actor }}
-          DOCKER_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           kubectl cluster-info
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-          PROPELLER=${{ secrets.flytegithub_repo }}/flytepropeller:${{ github.sha }} make end2end_execute
-  push-dockerhub:
+          IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:latest make end2end_execute
+
+  integration:
     runs-on: ubuntu-latest
+    needs: [build-docker]
     steps:
-      - uses: actions/checkout@v2
-      - name: Push Docker Image to Dockerhub
-        uses: whoan/docker-build-with-cache-action@v5
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: load-docker-cache
+        name: Load Docker Cache
+        uses: actions/cache@v1
         with:
-          username: "${{ secrets.DOCKERHUB_USERNAME }}"
-          password: "${{ secrets.DOCKERHUB_PASSWORD }}"
-          image_name: ${{ secrets.DOCKERHUB_IMAGE_NAME }}
-          image_tag: ${{ github.sha }}
-          push_git_tag: true
-          build_extra_args: "--compress=true"
+          path: /tmp/tmp/docker-images
+          key: /tmp/docker-images-${{ github.event.after }}
+      - name: Prime docker cache
+        run: docker load -i /tmp/tmp/docker-images/snapshot-builder.tar || true
+      - uses: engineerd/setup-kind@v0.4.0
+      - name: Integration
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
+          IMAGE_NAME=${{ github.event.repository.name }} IMAGE=lyft/${{ github.event.repository.name }}:builder make k8s_integration_execute
+
   tests-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Unit Tests
         uses: cedrickring/golang-action@1.5.2
         env:


### PR DESCRIPTION
# TL;DR
- Fixes docker caching key to use current SHA as the key with fallback from previous SHA and base SHA this ensures the docker cache gets persisted and make it available for subsequent builds
- Avoids rebuilding the image for each registry build by leveraging the cache
- Parallelizes a couple of steps that were serialized before
- Uses the same github workflow used in flyteadmin... paving the way to having a single source of truth in github.com/lyft/boilerplate of these workflows.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/579