### PR TITLE
Fix node execution for tasks in new events

### DIFF
--- a/pkg/controller/nodes/dynamic/dynamic_workflow.go
+++ b/pkg/controller/nodes/dynamic/dynamic_workflow.go
@@ -47,7 +47,7 @@ func (d dynamicNodeTaskNodeHandler) buildDynamicWorkflowTemplate(ctx context.Con
 		nodeID := node.Id
 		var subNodeStatus v1alpha1.ExecutableNodeStatus
 		if nCtx.ExecutionContext().GetEventVersion() == v1alpha1.EventVersion0 {
-			newID, err := hierarchicalNodeID(parentNodeID, currentAttemptStr, node.Id)
+			newID, err := hierarchicalNodeID(parentNodeID, currentAttemptStr, nodeID)
 			if err != nil {
 				return nil, err
 			}
@@ -69,7 +69,6 @@ func (d dynamicNodeTaskNodeHandler) buildDynamicWorkflowTemplate(ctx context.Con
 		if err != nil {
 			return nil, err
 		}
-
 		subNodeStatus.SetDataDir(originalNodePath)
 		subNodeStatus.SetOutputDir(outputDir)
 	}

--- a/pkg/controller/nodes/task/handler_test.go
+++ b/pkg/controller/nodes/task/handler_test.go
@@ -446,6 +446,8 @@ func Test_task_Handle_NoCatalog(t *testing.T) {
 
 		executionContext := &mocks.ExecutionContext{}
 		executionContext.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+		executionContext.OnGetEventVersion().Return(v1alpha1.EventVersion0)
+		executionContext.OnGetParentInfo().Return(nil)
 		nCtx.OnExecutionContext().Return(executionContext)
 
 		st := bytes.NewBuffer([]byte{})
@@ -768,6 +770,8 @@ func Test_task_Handle_Catalog(t *testing.T) {
 
 		executionContext := &mocks.ExecutionContext{}
 		executionContext.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+		executionContext.OnGetEventVersion().Return(v1alpha1.EventVersion0)
+		executionContext.OnGetParentInfo().Return(nil)
 		nCtx.OnExecutionContext().Return(executionContext)
 
 		nCtx.OnRawOutputPrefix().Return("s3://sandbox/")
@@ -992,6 +996,8 @@ func Test_task_Handle_Barrier(t *testing.T) {
 
 		executionContext := &mocks.ExecutionContext{}
 		executionContext.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+		executionContext.OnGetEventVersion().Return(v1alpha1.EventVersion0)
+		executionContext.OnGetParentInfo().Return(nil)
 		nCtx.OnExecutionContext().Return(executionContext)
 
 		nCtx.OnRawOutputPrefix().Return("s3://sandbox/")
@@ -1264,6 +1270,7 @@ func Test_task_Abort(t *testing.T) {
 
 		executionContext := &mocks.ExecutionContext{}
 		executionContext.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+		executionContext.OnGetParentInfo().Return(nil)
 		nCtx.OnExecutionContext().Return(executionContext)
 
 		nCtx.OnRawOutputPrefix().Return("s3://sandbox/")
@@ -1404,6 +1411,7 @@ func Test_task_Finalize(t *testing.T) {
 
 	executionContext := &mocks.ExecutionContext{}
 	executionContext.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+	executionContext.OnGetParentInfo().Return(nil)
 	nCtx.OnExecutionContext().Return(executionContext)
 
 	nCtx.OnRawOutputPrefix().Return("s3://sandbox/")

--- a/pkg/controller/nodes/task/taskexec_context.go
+++ b/pkg/controller/nodes/task/taskexec_context.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/lyft/flytepropeller/pkg/controller/nodes/common"
+
 	"github.com/lyft/flytepropeller/pkg/controller/nodes/task/resourcemanager"
 
 	"github.com/lyft/flytestdlib/logger"
@@ -124,7 +126,11 @@ func (t *Handler) newTaskExecutionContext(ctx context.Context, nCtx handler.Node
 
 	id := GetTaskExecutionIdentifier(nCtx)
 
-	uniqueID, err := utils.FixedLengthUniqueIDForParts(IDMaxLength, nCtx.NodeExecutionMetadata().GetOwnerID().Name, nCtx.NodeID(), strconv.Itoa(int(id.RetryAttempt)))
+	currentNodeUniqueID, err := common.GenerateUniqueID(nCtx.ExecutionContext().GetParentInfo(), nCtx.NodeID())
+	if err != nil {
+		return nil, err
+	}
+	uniqueID, err := utils.FixedLengthUniqueIDForParts(IDMaxLength, nCtx.NodeExecutionMetadata().GetOwnerID().Name, currentNodeUniqueID, strconv.Itoa(int(id.RetryAttempt)))
 	if err != nil {
 		// SHOULD never really happen
 		return nil, err

--- a/pkg/controller/nodes/task/taskexec_context_test.go
+++ b/pkg/controller/nodes/task/taskexec_context_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"testing"
 
+	mocks2 "github.com/lyft/flytepropeller/pkg/controller/executors/mocks"
+
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/lyft/flyteplugins/go/tasks/pluginmachinery/catalog/mocks"
 	ioMocks "github.com/lyft/flyteplugins/go/tasks/pluginmachinery/io/mocks"
@@ -74,6 +76,11 @@ func TestHandler_newTaskExecutionContext(t *testing.T) {
 	nCtx.OnNodeID().Return(nodeID)
 	nCtx.OnEventsRecorder().Return(nil)
 	nCtx.OnEnqueueOwnerFunc().Return(nil)
+
+	executionContext := &mocks2.ExecutionContext{}
+	executionContext.OnGetExecutionConfig().Return(v1alpha1.ExecutionConfig{})
+	executionContext.OnGetParentInfo().Return(nil)
+	nCtx.OnExecutionContext().Return(executionContext)
 
 	ds, err := storage.NewDataStore(
 		&storage.Config{


### PR DESCRIPTION
The task events are still using older nodeId format even on the newer event version

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

