### PR TITLE
[Compiler] Compiling a compiled WF leads to compile errors

### DIFF
--- a/pkg/compiler/validators/node.go
+++ b/pkg/compiler/validators/node.go
@@ -120,6 +120,10 @@ func ValidateNode(w c.WorkflowBuilder, n c.NodeBuilder, validateConditionTypes b
 		errs.Collect(errors.NewValueRequiredErr("<node>", "Id"))
 	}
 
+	if n.GetId() == c.StartNodeID || n.GetId() == c.EndNodeID {
+		return true
+	}
+
 	if _, ifaceOk := ValidateUnderlyingInterface(w, n, errs.NewScope()); ifaceOk {
 		// Validate node output aliases
 		validateEffectiveOutputParameters(n, errs.NewScope())

--- a/pkg/compiler/validators/node_test.go
+++ b/pkg/compiler/validators/node_test.go
@@ -3,6 +3,8 @@ package validators
 import (
 	"testing"
 
+	"github.com/lyft/flytepropeller/pkg/compiler/common"
+
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 
 	"github.com/lyft/flytepropeller/pkg/compiler/common/mocks"
@@ -32,4 +34,16 @@ func TestValidateBranchNode(t *testing.T) {
 			assert.Equal(t, errors.BranchNodeHasNoDefault, errsList[1].Code())
 		}
 	})
+}
+
+func TestValidateNode(t *testing.T) {
+	n := &mocks.NodeBuilder{}
+	n.OnGetId().Return(common.StartNodeID)
+
+	wf := &mocks.WorkflowBuilder{}
+	errs := errors.NewCompileErrors()
+	ValidateNode(wf, n, true, errs)
+	if errs.HasErrors() {
+		assert.NoError(t, errs)
+	}
 }


### PR DESCRIPTION
# TL;DR
When a workflow has two nodes both of type WorkflowNodes and attempt to execute the same SubWF, the compiler attempts to compile the SubWorkflow twice (opportunity for optimization).. When it does the second time, it fails because validating Start and End nodes doesn't pass due to them not having targets (by design)... the fix is to handle start and end nodes specially...
The ultimate fix is to avoid compiling twice to begin with.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/633