### PR TITLE
Option for cleanup pod after last retry failure

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -127,7 +127,7 @@ type NodeConfig struct {
 	DefaultDeadlines               DefaultDeadlines `json:"default-deadlines,omitempty" pflag:",Default value for timeouts"`
 	MaxNodeRetriesOnSystemFailures int64            `json:"max-node-retries-system-failures" pflag:"2,Maximum number of retries per node for node failure due to infra issues"`
 	InterruptibleFailureThreshold  int64            `json:"interruptible-failure-threshold" pflag:"1,number of failures for a node to be still considered interruptible'"`
-	CleanupLastRetry           bool             	`json:"cleanup-last-retry" pflag:",Enables/Disables removing the custom resource after retries exhausted."`
+	CleanupLastRetry               bool             `json:"cleanup-last-retry" pflag:",Enables/Disables removing the custom resource after retries exhausted."`
 }
 
 // Contains default values for timeouts

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -46,7 +46,7 @@ var (
 			},
 			MaxNodeRetriesOnSystemFailures: 3,
 			InterruptibleFailureThreshold:  1,
-			CleanupLastRetry:           false,
+			CleanupLastRetry:               false,
 		},
 	}
 )

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -46,6 +46,7 @@ var (
 			},
 			MaxNodeRetriesOnSystemFailures: 3,
 			InterruptibleFailureThreshold:  1,
+			CleanupLastRetry:           false,
 		},
 	}
 )
@@ -126,6 +127,7 @@ type NodeConfig struct {
 	DefaultDeadlines               DefaultDeadlines `json:"default-deadlines,omitempty" pflag:",Default value for timeouts"`
 	MaxNodeRetriesOnSystemFailures int64            `json:"max-node-retries-system-failures" pflag:"2,Maximum number of retries per node for node failure due to infra issues"`
 	InterruptibleFailureThreshold  int64            `json:"interruptible-failure-threshold" pflag:"1,number of failures for a node to be still considered interruptible'"`
+	CleanupLastRetry           bool             	`json:"cleanup-last-retry" pflag:",Enables/Disables removing the custom resource after retries exhausted."`
 }
 
 // Contains default values for timeouts

--- a/pkg/controller/config/config_flags.go
+++ b/pkg/controller/config/config_flags.go
@@ -83,5 +83,6 @@ func (cfg Config) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "node-config.default-deadlines.workflow-active-deadline"), defaultConfig.NodeConfig.DefaultDeadlines.DefaultWorkflowActiveDeadline.String(), "Default value of workflow timeout")
 	cmdFlags.Int64(fmt.Sprintf("%v%v", prefix, "node-config.max-node-retries-system-failures"), defaultConfig.NodeConfig.MaxNodeRetriesOnSystemFailures, "Maximum number of retries per node for node failure due to infra issues")
 	cmdFlags.Int64(fmt.Sprintf("%v%v", prefix, "node-config.interruptible-failure-threshold"), defaultConfig.NodeConfig.InterruptibleFailureThreshold, "number of failures for a node to be still considered interruptible'")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "node-config.cleanup-last-retry"), defaultConfig.NodeConfig.CleanupLastRetry, "Enables/Disables removing the custom resource after retries exhausted.")
 	return cmdFlags
 }

--- a/pkg/controller/config/config_flags_test.go
+++ b/pkg/controller/config/config_flags_test.go
@@ -1023,4 +1023,26 @@ func TestConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_node-config.cleanup-last-retry", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vBool, err := cmdFlags.GetBool("node-config.cleanup-last-retry"); err == nil {
+				assert.Equal(t, bool(defaultConfig.NodeConfig.CleanupLastRetry), vBool)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("node-config.cleanup-last-retry", testValue)
+			if vBool, err := cmdFlags.GetBool("node-config.cleanup-last-retry"); err == nil {
+				testDecodeJson_Config(t, fmt.Sprintf("%v", vBool), &actual.NodeConfig.CleanupLastRetry)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 }

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -246,7 +246,7 @@ func (c *nodeExecutor) execute(ctx context.Context, h handler.Node, nCtx *nodeEx
 		currentAttempt, maxAttempts, isEligible := c.isEligibleForRetry(nCtx, nodeStatus, phase.GetErr())
 
 		if !c.cleanupLastRetry && !isEligible {
-			logger.Errorf(ctx, "Transit node phase to failure")
+			logger.Debugf(ctx, "Transit node phase to failure")
 			return handler.PhaseInfoFailure(
 				core.ExecutionError_USER,
 				fmt.Sprintf("RetriesExhausted|%s", phase.GetErr().Code),

--- a/pkg/controller/nodes/executor.go
+++ b/pkg/controller/nodes/executor.go
@@ -77,7 +77,7 @@ type nodeExecutor struct {
 	interruptibleFailureThreshold   uint32
 	defaultDataSandbox              storage.DataReference
 	shardSelector                   ioutils.ShardSelector
-	cleanupLastRetry            bool
+	cleanupLastRetry                bool
 }
 
 func (c *nodeExecutor) RecordTransitionLatency(ctx context.Context, dag executors.DAGStructure, nl executors.NodeLookup, node v1alpha1.ExecutableNode, nodeStatus v1alpha1.ExecutableNodeStatus) {
@@ -930,7 +930,7 @@ func NewExecutor(ctx context.Context, nodeConfig config.NodeConfig, store *stora
 		interruptibleFailureThreshold:   uint32(nodeConfig.InterruptibleFailureThreshold),
 		defaultDataSandbox:              defaultRawOutputPrefix,
 		shardSelector:                   shardSelector,
-		cleanupLastRetry:            nodeConfig.CleanupLastRetry,
+		cleanupLastRetry:                nodeConfig.CleanupLastRetry,
 	}
 	nodeHandlerFactory, err := NewHandlerFactory(ctx, exec, workflowLauncher, launchPlanReader, kubeClient, catalogClient, nodeScope)
 	exec.nodeHandlerFactory = nodeHandlerFactory

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -479,7 +479,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		}
 
 		var err *v1alpha1.ExecutionError
-		if p == v1alpha1.NodePhaseFailing || p == v1alpha1.NodePhaseFailed {
+		if p == v1alpha1.NodePhaseFailing || p == v1alpha1.NodePhaseFailed || p == v1alpha1.NodePhaseRetryableFailure{
 			err = &v1alpha1.ExecutionError{ExecutionError: &core.ExecutionError{Code: "test", Message: "test"}}
 		}
 		ns := &v1alpha1.NodeStatus{
@@ -962,6 +962,69 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		assert.Equal(t, executors.NodePhasePending.String(), s.NodePhase.String())
 		assert.Equal(t, uint32(0), mockNodeStatus.GetAttempts())
 		assert.Equal(t, v1alpha1.NodePhaseFailing.String(), mockNodeStatus.GetPhase().String())
+	})
+
+	// not fail immediately for last retry failure when enabled cleanupLastRetry
+	t.Run("not-fail-immediately-for-last-failure", func(t *testing.T) {
+		hf := &mocks2.HandlerFactory{}
+		store := createInmemoryDataStore(t, promutils.NewTestScope())
+		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
+		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, promutils.NewTestScope())
+		assert.NoError(t, err)
+		exec := execIface.(*nodeExecutor)
+		exec.cleanupLastRetry = true
+		exec.nodeHandlerFactory = hf
+
+		h := &nodeHandlerMocks.Node{}
+		h.On("Handle",
+			mock.MatchedBy(func(ctx context.Context) bool { return true }),
+			mock.MatchedBy(func(o handler.NodeExecutionContext) bool { return true }),
+		).Return(handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRetryableFailure(core.ExecutionError_USER, "x", "y", nil)), nil)
+		h.On("FinalizeRequired").Return(true)
+		h.On("Finalize", mock.Anything, mock.Anything).Return(fmt.Errorf("error"))
+		hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
+
+		mockWf, _, mockNodeStatus := createSingleNodeWf(v1alpha1.NodePhaseRunning, 1)
+		startNode := mockWf.StartNode()
+		execContext := executors.NewExecutionContext(mockWf, mockWf, nil, nil)
+		s, err := exec.RecursiveNodeHandler(ctx, execContext, mockWf, mockWf, startNode)
+		assert.NoError(t, err)
+		assert.Equal(t, executors.NodePhasePending.String(), s.NodePhase.String())
+		assert.Equal(t, uint32(0), mockNodeStatus.GetAttempts())
+		assert.Equal(t, v1alpha1.NodePhaseRetryableFailure.String(), mockNodeStatus.GetPhase().String())
+	})
+
+	// Clean up last retry
+	t.Run("retries-last-cleanup", func(t *testing.T) {
+		hf := &mocks2.HandlerFactory{}
+		store := createInmemoryDataStore(t, promutils.NewTestScope())
+		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
+		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, promutils.NewTestScope())
+		assert.NoError(t, err)
+		exec := execIface.(*nodeExecutor)
+		exec.cleanupLastRetry = true
+		exec.nodeHandlerFactory = hf
+
+		h := &nodeHandlerMocks.Node{}
+		h.On("Handle",
+			mock.MatchedBy(func(ctx context.Context) bool { return true }),
+			mock.MatchedBy(func(o handler.NodeExecutionContext) bool { return true }),
+		).Return(handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRetryableFailure(core.ExecutionError_USER, "x", "y", nil)), nil)
+		h.On("FinalizeRequired").Return(true)
+		h.On("Finalize", mock.Anything, mock.Anything).Return(nil)
+		h.On("Abort", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
+
+		mockWf, _, mockNodeStatus := createSingleNodeWf(v1alpha1.NodePhaseRetryableFailure, 0)
+		startNode := mockWf.StartNode()
+		execContext := executors.NewExecutionContext(mockWf, mockWf, nil, nil)
+		s, err := exec.RecursiveNodeHandler(ctx, execContext, mockWf, mockWf, startNode)
+		assert.NoError(t, err)
+		assert.Equal(t, executors.NodePhaseFailed.String(), s.NodePhase.String())
+		assert.Equal(t, uint32(0), mockNodeStatus.GetAttempts())
+		assert.Equal(t, v1alpha1.NodePhaseRetryableFailure.String(), mockNodeStatus.GetPhase().String())
 	})
 }
 

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -977,13 +977,13 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		exec.nodeHandlerFactory = hf
 
 		h := &nodeHandlerMocks.Node{}
-		h.On("Handle",
+		h.OnHandleMatch(
 			mock.MatchedBy(func(ctx context.Context) bool { return true }),
 			mock.MatchedBy(func(o handler.NodeExecutionContext) bool { return true }),
 		).Return(handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRetryableFailure(core.ExecutionError_USER, "x", "y", nil)), nil)
-		h.On("FinalizeRequired").Return(true)
-		h.On("Finalize", mock.Anything, mock.Anything).Return(fmt.Errorf("error"))
-		hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
+		h.OnFinalizeRequiredMatch().Return(true)
+		h.OnFinalizeMatch(mock.Anything, mock.Anything).Return(fmt.Errorf("error"))
+		hf.OnGetHandlerMatch(v1alpha1.NodeKindTask).Return(h, nil)
 
 		mockWf, _, mockNodeStatus := createSingleNodeWf(v1alpha1.NodePhaseRunning, 1)
 		startNode := mockWf.StartNode()
@@ -1008,14 +1008,10 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		exec.nodeHandlerFactory = hf
 
 		h := &nodeHandlerMocks.Node{}
-		h.On("Handle",
-			mock.MatchedBy(func(ctx context.Context) bool { return true }),
-			mock.MatchedBy(func(o handler.NodeExecutionContext) bool { return true }),
-		).Return(handler.DoTransition(handler.TransitionTypeEphemeral, handler.PhaseInfoRetryableFailure(core.ExecutionError_USER, "x", "y", nil)), nil)
-		h.On("FinalizeRequired").Return(true)
-		h.On("Finalize", mock.Anything, mock.Anything).Return(nil)
-		h.On("Abort", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
+		h.OnFinalizeRequiredMatch().Return(true)
+		h.OnFinalizeMatch(mock.Anything, mock.Anything).Return(nil)
+		h.OnAbortMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
+		hf.OnGetHandlerMatch(v1alpha1.NodeKindTask).Return(h, nil)
 
 		mockWf, _, mockNodeStatus := createSingleNodeWf(v1alpha1.NodePhaseRetryableFailure, 0)
 		startNode := mockWf.StartNode()
@@ -1023,6 +1019,34 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		s, err := exec.RecursiveNodeHandler(ctx, execContext, mockWf, mockWf, startNode)
 		assert.NoError(t, err)
 		assert.Equal(t, executors.NodePhaseFailed.String(), s.NodePhase.String())
+		assert.Equal(t, uint32(0), mockNodeStatus.GetAttempts())
+		assert.Equal(t, v1alpha1.NodePhaseRetryableFailure.String(), mockNodeStatus.GetPhase().String())
+	})
+
+	// Abort error when clean up last retry
+	t.Run("abort-error-retries-last-cleanup", func(t *testing.T) {
+		hf := &mocks2.HandlerFactory{}
+		store := createInmemoryDataStore(t, promutils.NewTestScope())
+		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
+		execIface, err := NewExecutor(ctx, config.GetConfig().NodeConfig, store, enQWf, mockEventSink, adminClient,
+			adminClient, 10, "s3://bucket", fakeKubeClient, catalogClient, promutils.NewTestScope())
+		assert.NoError(t, err)
+		exec := execIface.(*nodeExecutor)
+		exec.cleanupLastRetry = true
+		exec.nodeHandlerFactory = hf
+
+		h := &nodeHandlerMocks.Node{}
+		h.OnFinalizeRequiredMatch().Return(true)
+		h.OnFinalizeMatch(mock.Anything, mock.Anything).Return(nil)
+		h.OnAbortMatch(mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("error"))
+		hf.OnGetHandlerMatch(v1alpha1.NodeKindTask).Return(h, nil)
+
+		mockWf, _, mockNodeStatus := createSingleNodeWf(v1alpha1.NodePhaseRetryableFailure, 0)
+		startNode := mockWf.StartNode()
+		execContext := executors.NewExecutionContext(mockWf, mockWf, nil, nil)
+		s, err := exec.RecursiveNodeHandler(ctx, execContext, mockWf, mockWf, startNode)
+		assert.Error(t, err)
+		assert.Equal(t, executors.NodePhaseUndefined.String(), s.NodePhase.String())
 		assert.Equal(t, uint32(0), mockNodeStatus.GetAttempts())
 		assert.Equal(t, v1alpha1.NodePhaseRetryableFailure.String(), mockNodeStatus.GetPhase().String())
 	})

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -479,7 +479,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 		}
 
 		var err *v1alpha1.ExecutionError
-		if p == v1alpha1.NodePhaseFailing || p == v1alpha1.NodePhaseFailed || p == v1alpha1.NodePhaseRetryableFailure{
+		if p == v1alpha1.NodePhaseFailing || p == v1alpha1.NodePhaseFailed || p == v1alpha1.NodePhaseRetryableFailure {
 			err = &v1alpha1.ExecutionError{ExecutionError: &core.ExecutionError{Code: "test", Message: "test"}}
 		}
 		ns := &v1alpha1.NodeStatus{


### PR DESCRIPTION
# TL;DR
The default behaviour after the last retry failure is leaving the pod and it will be cleaned when gc happens. In that case, before gc happens the pods still consume k8s resource and after a few executions of a miss configure workflow, no new execution could be done on the namespace because of quota. 

When enabling the option `cleanup-last-retry`, when last retry failed, the pod will also be cleanup. 

When last retry failed the node will still go to `EPhaseRetryableFailure` and in the `handleRetryableFailure` function, the pod will be cleaned up and node transit to failed state.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/651

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
