### PR TITLE
Remove pods for imagePullBackOff

### DIFF
--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -875,7 +875,12 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 				}
 				hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
 
-				mockWf, _, mockNodeStatus := createSingleNodeWf(test.currentNodePhase, 1)
+				maxAttempts := 1
+				if test.currentNodePhase == v1alpha1.NodePhaseRetryableFailure {
+					// For case retryableFailure -> running, the attempts should less that maxAttempts
+					maxAttempts = 2
+				}
+				mockWf, _, mockNodeStatus := createSingleNodeWf(test.currentNodePhase, maxAttempts)
 				execErr := mockNodeStatus.GetExecutionError()
 				startNode := mockWf.StartNode()
 				execContext := executors.NewExecutionContext(mockWf, mockWf, nil, nil)
@@ -965,7 +970,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 	})
 
 	// not fail immediately for last retry failure when ImagePullBackOff
-	t.Run("not-fail-immediately-for-last-failure", func(t *testing.T) {
+	t.Run("imagePullBackOff-not-fail-immediately-for-last-failure", func(t *testing.T) {
 		hf := &mocks2.HandlerFactory{}
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
@@ -995,7 +1000,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 	})
 
 	// Clean up pod last retry for ImagePullBackOff
-	t.Run("retries-last-cleanup", func(t *testing.T) {
+	t.Run("imagePullBackOff-last-retries-cleanup", func(t *testing.T) {
 		hf := &mocks2.HandlerFactory{}
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
@@ -1022,7 +1027,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 	})
 
 	// Abort error when clean up last retry
-	t.Run("abort-error-retries-last-cleanup", func(t *testing.T) {
+	t.Run("imagePullBackOff-abort-error-retries-last-cleanup", func(t *testing.T) {
 		hf := &mocks2.HandlerFactory{}
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()

--- a/pkg/controller/nodes/executor_test.go
+++ b/pkg/controller/nodes/executor_test.go
@@ -815,7 +815,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 				},
 				false, true, core.NodeExecution_FAILED, 0},
 
-			{"retryablefailure->running", v1alpha1.NodePhaseRetryableFailure, v1alpha1.NodePhaseRunning, executors.NodePhasePending, func() (handler.Transition, error) {
+			{"retryableFailure->running", v1alpha1.NodePhaseRetryableFailure, v1alpha1.NodePhaseRunning, executors.NodePhasePending, func() (handler.Transition, error) {
 				return handler.UnknownTransition, fmt.Errorf("should not be invoked")
 			}, false, false, core.NodeExecution_RUNNING, 1},
 
@@ -876,7 +876,8 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 				hf.On("GetHandler", v1alpha1.NodeKindTask).Return(h, nil)
 
 				maxAttempts := 1
-				if test.currentNodePhase == v1alpha1.NodePhaseRetryableFailure {
+				if test.currentNodePhase == v1alpha1.NodePhaseRetryableFailure &&
+					test.expectedNodePhase == v1alpha1.NodePhaseRunning {
 					// For case retryableFailure -> running, the attempts should less that maxAttempts
 					maxAttempts = 2
 				}
@@ -1000,7 +1001,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 	})
 
 	// Clean up pod last retry for ImagePullBackOff
-	t.Run("imagePullBackOff-last-retries-cleanup", func(t *testing.T) {
+	t.Run("last-retries-cleanup", func(t *testing.T) {
 		hf := &mocks2.HandlerFactory{}
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()
@@ -1027,7 +1028,7 @@ func TestNodeExecutor_RecursiveNodeHandler_Recurse(t *testing.T) {
 	})
 
 	// Abort error when clean up last retry
-	t.Run("imagePullBackOff-abort-error-retries-last-cleanup", func(t *testing.T) {
+	t.Run("abort-error-retries-last-cleanup", func(t *testing.T) {
 		hf := &mocks2.HandlerFactory{}
 		store := createInmemoryDataStore(t, promutils.NewTestScope())
 		adminClient := launchplan.NewFailFastLaunchPlanExecutor()


### PR DESCRIPTION
# TL;DR
Clean up pod because of imagePullBackOff. This is an alternative for https://github.com/lyft/flytepropeller/pull/212 and of issue: https://github.com/lyft/flyte/issues/651.

We will always clean up the pods failed due to ImagePullBackOff.

The approach is similar to the other PR: When last retry failed in case of ImagePullBackOff the node will still go to EPhaseRetryableFailure and in the handleRetryableFailure function, the pod will be cleaned up and node transit to failed state.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
 https://github.com/lyft/flyte/issues/651

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
