### PR TITLE
Revert "Pass command-line arguments"

### DIFF
--- a/cmd/controller/cmd/root.go
+++ b/cmd/controller/cmd/root.go
@@ -97,13 +97,11 @@ func init() {
 	rootCmd.AddCommand(viper.GetConfigCommand())
 }
 
-func initConfig(cmd *cobra.Command, _ []string) error {
+func initConfig(_ *cobra.Command, _ []string) error {
 	configAccessor = viper.NewAccessor(config.Options{
 		StrictMode:  true,
 		SearchPaths: []string{cfgFile},
 	})
-
-	configAccessor.InitializePflags(cmd.Flags())
 
 	err := configAccessor.UpdateConfig(context.TODO())
 	if err != nil {


### PR DESCRIPTION
Reverts lyft/flytepropeller#193

I'm not sure why this wasn't caught in the End-To-End tests but running Propeller in a cluster goes into a crashloop because of this change...
The error is:
```
strict mode is on but received keys [map[add_dir_header:false alsologtostderr:false config:/etc/flyte/config/*.yaml ginkgo:map[debug:false dryrun:false failfast:false failonpending:false flakeattempts:1 focus: nocolor:false noisypendings:true noisyskippings:true parallel:map[node:1 streamhost: synchost: total:1] progress:false randomizeallspecs:false regexscansfilepath:false reportfile: reportpassed:false seed:1611672198 skip: skipmeasurements:false slowspecthreshold:5 succinct:false trace:false v:false] help:false kubeconfig: log_backtrace_at::0 log_dir: log_file: log_file_max_size:1800 logtostderr:true master: skip_headers:false skip_log_headers:false stderrthreshold:2 v:0 vmodule:]] to decode with no config assigned to receive them: failed strict mode check
```

I'm not sure why... these flags are not being passed to propeller but they are part of klog (line 83)... could that be the reason? It needs further debugging. If you've the time to dig deeper, that would be great. Otherwise, unfortunately, this will go back to our backlog..